### PR TITLE
Update with LEWGI feedback from San Diego.

### DIFF
--- a/D0876R4.tex
+++ b/D0876R4.tex
@@ -31,7 +31,7 @@
             pdftex,
             pdfsubject  = {},
             pdfauthor   = {Oliver Kowalke},
-            pdfkeywords = {C++,callcc,call/cc,context,continuation,coroutine,execution,fiber,fiber_handle,switch,P0099,P0534,P0876},
+            pdfkeywords = {C++,callcc,call/cc,context,continuation,coroutine,execution,fiber,fiber_context,switch,P0099,P0534,P0876},
             pdftitle    = {fibers without scheduler}]{hyperref}
 
 %//////////////////////////////////////////////////////////////////////////////
@@ -43,14 +43,14 @@
 \begin{document}
 \small
 \begin{tabbing}
-    Document number: \= P0876R3\\
-    Date:            \> 2018-06-08\\
+    Document number: \= D0876R4\\
+    Date:            \> 2018-11-06\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
-    Audience:        \> LEWG\\
+    Audience:        \> LEWG, LEWGI\\
 \end{tabbing}
 
-\section*{\emph{fiber\_handle} - fibers without scheduler}
+\section*{\emph{fiber\_context} - fibers without scheduler}
 
 %//////////////////////////////////////////////////////////////////////////////
 
@@ -59,19 +59,19 @@
 %//////////////////////////////////////////////////////////////////////////////
 
 \abschnitt{Revision History}
-This document supersedes P0876R2.\\
+This document supersedes P0876R3.\\
 \newline
-Changes since P0876R2.
+Changes since P0876R3:
 
 \begin{itemize}
-    \item rename \cpp{fiber\_context} to \cpp{fiber\_handle}
-    \item remove \emph{StackAllocator} constructor and related material
-    \item rename \cpp{resume\_other\_thread()} to \xtresume
-    \item rename \cpp{resume\_other\_thread\_with()} to \xtresumewith
-    \item replace \cpp{uses\_system\_stack()} with
-          \canxtresume (with inverted return sense)
-    \item replace \cpp{previous\_thread()} with \canresume
-          (with bool return)
+    \item rename \cpp{fiber\_handle} back to \cpp{fiber\_context}
+    \item accept ``invokable'' rather than ``callable''
+    \item add \cpp{bool valid()} method
+    \item mark \cpp{unwind\_fiber()}\xspace\cpp{[[noreturn]]}
+    \item \cpp{resume()} or \cpp{resume\_with()} from different thread becomes UB
+    \item state more definitely when the implementation will throw
+    \item remove precondition from \cpp{can\_resume()}, \cpp{can\_resume\_from\_any\_thread()}
+    \item remove \cpp{operator<()}
 \end{itemize}
 
 \input{abstract}

--- a/abstract.tex
+++ b/abstract.tex
@@ -8,7 +8,7 @@ Because of name clashes with \emph{coroutine} from coroutine TS,
 \emph{execution context} from executor proposals and \emph{continuation} used
 in the context of \cpp{future::then()}, the committee has indicated
 that \emph{fiber} is preferable. However, given the foundational, low-level
-nature of this proposal, we choose \emph{fiber\_handle}, leaving the
+nature of this proposal, we choose \emph{fiber\_context}, leaving the
 term \emph{fiber} for a higher-level facility built on top of this one.\\
 
 A previous revision of this proposal suggested \emph{fiber\_context}, but SG1

--- a/api.tex
+++ b/api.tex
@@ -151,13 +151,6 @@ resumes a fiber\\
     \item[fn] invokable injected into resumed fiber\\
 \end{description}
 
-{\bfseries Preconditions}
-\begin{description}
-    \item[1),2),3),4)] \cpp{*this} is valid (\cpp{valid()} returns \cpp{true})
-    \item[1),2)] the current \thread is the same as the thread on
-              which the fiber represented by \cpp{*this} was most recently run
-\end{description}
-
 {\bfseries Return value}
 \begin{description}
     \item[fiber\_context] the returned instance represents the fiber that has been
@@ -188,11 +181,11 @@ resumes a fiber\\
 {\bfseries Preconditions}
 \begin{description}
     \item[1)] \cpp{*this} represents a valid fiber (\cpp{valid()} returns \cpp{true})
-    \item[2)] for \resume and \resumewith, the current \thread is the same as
-              the thread on which \cpp{*this} was most recently run
+    \item[2)] for \resume and \resumewith, \currthread is the same as
+              \lastthread
     \item[3)] for \resume, \resumewith, \xtresume and \xtresumewith, if\\
-              \canxtresume would return \cpp{false}, the current \thread is
-              the same as the thread represented by \cpp{*this}
+              \canxtresume would return \cpp{false}, \currthread is
+              the same as \lastthread
 \end{description}
 
 {\bfseries Postcondition}
@@ -209,11 +202,11 @@ will ever be resumed on a thread other than the one on which it was initially
 resumed. Any attempt to do so will throw.\\
 
 The intent of the names \xtresume and \xtresumewith is to clarify the
-direction in which cross-thread resumption occurs. The calling thread always
+direction in which cross-thread resumption occurs. \Currthread always
 directly resumes a suspended fiber: control is passed into the suspended
 fiber, and the currently-running fiber suspends. These method names mean that
 the fiber represented by \cpp{*this} will be resumed whether or not it was
-last resumed on the calling thread.\\
+last resumed on \currthread.\\
 
 \resume, \resumewith, \xtresume and \xtresumewith preserve the execution
 context of the calling fiber. Those data are restored if the calling fiber is
@@ -239,10 +232,10 @@ the return value for the suspended function: \resume, \resumewith, \xtresume
 or\\\xtresumewith.
 
 \subparagraph*{can\_resume\_from\_any\_thread()}
-query whether the calling thread can resume the suspended \fiber instance by
+query whether \currthread can resume the suspended \fiber instance by
 calling \xtresume or \xtresumewith. The implementation must return \cpp{false}
 if the suspended \fiber instance represents a fiber with a system-provided
-stack, and the calling thread is not that thread.\\
+stack, and \currthread is not that thread.\\
 
 \begin{tabular}{ l l }
     \midrule
@@ -256,7 +249,7 @@ stack, and the calling thread is not that thread.\\
     \item[1)] \cpp{fiber\_context::can\_resume\_from\_any\_thread()} returns \cpp{false}
         if \cpp{*this} does not represent a valid fiber, or
         if the stack used by the fiber was provided by the operating system,
-        and the calling thread is not that thread; otherwise \cpp{true}.
+        and \currthread is not that thread; otherwise \cpp{true}.
 \end{description}
 
 {\bfseries Notes}
@@ -267,8 +260,8 @@ suspended fiber. You may resume that suspended fiber \emph{on the same thread}
 using any of \resume, \resumewith, \xtresume or \xtresumewith. Attempting to
 resume that suspended fiber from any other thread is Undefined Behavior.
 
-\canxtresume returns \cpp{true} if the calling thread is the same as the
-thread represented by the\\\fiber instance, or if the \fiber instance
+\canxtresume returns \cpp{true} if \currthread is the same as \lastthread,
+or if the \fiber instance
 represents a fiber explicitly created by\\\fiber's constructor.
 
 \canxtresume is not marked \cpp{const} because in at least one
@@ -290,8 +283,7 @@ by \resume, \resumewith, \xtresume or \xtresumewith.\\
 
 \begin{description}
     \item[1)] returns \cpp{true} if \cpp{*this} represents a valid fiber,
-        and the calling thread is the same as the
-        thread on which \cpp{*this} was suspended. If the \fiber has not yet
+        and \currthread is the same as \lastthread. If the \fiber has not yet
         run and has therefore never been suspended, returns \cpp{true} as
         well.
 \end{description}
@@ -327,9 +319,7 @@ test whether \fiber is valid\\
 A \fiber instance might not represent a valid fiber for any of a number of reasons.
 \begin{itemize}
     \item It might have been default-constructed.
-    \item It might have been assigned to another instance, or passed into a
-          function.\\
-          \fiber instances are move-only.
+    \item It might have been moved from.
     \item It might already have been resumed -- calling \resume, \resumewith,
           \xtresume or\\
           \xtresumewith invalidates the instance.

--- a/api.tex
+++ b/api.tex
@@ -199,7 +199,7 @@ The intent of the distinction between \resume and \xtresume, as
 between \resumewith and \xtresumewith, is both for validation and for code
 auditing. If an application only ever calls \resume and \resumewith, no fiber
 will ever be resumed on a thread other than the one on which it was initially
-resumed. Any attempt to do so will throw.\\
+resumed.\\
 
 The intent of the names \xtresume and \xtresumewith is to clarify the
 direction in which cross-thread resumption occurs. \Currthread always
@@ -224,8 +224,9 @@ newly-invalidated instance -- the instance on which the method was was called
 -- with the new instance returned by that call. This helps to avoid subsequent
 inadvertent attempts to resume the old, invalidated instance.
 \newline
-An injected function \cpp{fn()} must accept \cpp{std::fiber\_context&&} and
-return \fiber. It will be passed a synthesized \fiber instance representing
+An injected function \cpp{fn()} must have signature
+\cpp{std::fiber\_context fn(std::fiber\_context&&)}.
+It will be passed a synthesized \fiber instance representing
 the suspended caller of \resumewith or\\
 \xtresumewith. The \fiber instance returned by \cpp{fn()} is, in turn, used as
 the return value for the suspended function: \resume, \resumewith, \xtresume
@@ -262,14 +263,14 @@ resume that suspended fiber from any other thread is Undefined Behavior.
 
 \canxtresume returns \cpp{true} if \currthread is the same as \lastthread,
 or if the \fiber instance
-represents a fiber explicitly created by\\\fiber's constructor.
+represents a fiber explicitly created by \fiber's constructor.
 
 \canxtresume is not marked \cpp{const} because in at least one
 implementation, it requires an internal context switch.
 
 \subparagraph*{can\_resume()}
-returns \cpp{true} if the \fiber instance was suspended on the same thread as
-the caller, or if it has not yet been resumed. When \canresume
+returns \cpp{true} if \currthread is the same as \lastthread,
+or if \cpp{*this} has not yet been resumed. When \canresume
 returns \cpp{true}, the \fiber instance may be resumed
 by \resume, \resumewith, \xtresume or \xtresumewith.\\
 

--- a/api.tex
+++ b/api.tex
@@ -1,41 +1,41 @@
 \newpage
 \abschnitt{API}\label{api}
 
-\uabschnitt{class fiber\_handle}
+\uabschnitt{class fiber\_context}
 
 \cppf{fiber}
 
 \paragraph*{member functions}
 
 \subparagraph*{(constructor)}
-constructs new \cpp{fiber\_handle}\\
+constructs new \cpp{fiber\_context}\\
 
 \begin{tabular}{ l l }
     \midrule
 
-    \cpp{fiber\_handle() noexcept} & (1)\\
+    \cpp{fiber\_context() noexcept} & (1)\\
 
     \midrule
 
     \cpp{template<typename Fn>}\\
-    \cpp{explicit fiber\_handle(Fn&& fn)} & (2)\\
+    \cpp{explicit fiber\_context(Fn&& fn)} & (2)\\
 
     \midrule
 
-    \cpp{fiber\_handle(fiber\_handle&& other) noexcept} & (3)\\
+    \cpp{fiber\_context(fiber\_context&& other) noexcept} & (3)\\
 
     \midrule
 
-    \cpp{fiber\_handle(const fiber\_handle& other)=delete} & (4)\\
+    \cpp{fiber\_context(const fiber\_context& other)=delete} & (4)\\
 
     \midrule
 \end{tabular}
 
 \begin{description}
-    \item[1)] this constructor instantiates an invalid \fiber. Its \opbool
+    \item[1)] this constructor instantiates an invalid \fiber. Its \cpp{valid()} method
               returns \cpp{false}.
-    \item[2)] takes a callable (function, lambda, object with \op) as
-              argument. The callable must have signature as described
+    \item[2)] takes an invokable (function, lambda, object with \op) as
+              argument. The invokable must have signature as described
               in \nameref{solution_gpub}.
     \item[3)] moves underlying state to new \fiber
     \item[4)] copy constructor deleted
@@ -66,7 +66,7 @@ destroys a fiber\\
 
 \begin{description}
     \item[1)] destroys a \fiber instance. If this instance represents a fiber
-              of execution (\opbool returns \cpp{true}), then the fiber of
+              of execution (\cpp{valid()} returns \cpp{true}), then the fiber of
               execution is destroyed too. Specifically, the stack is unwound
               by throwing \unwindex.\footnote{ In a program in which exceptions
               are thrown, it is prudent to code a fiber's \entryfn\xspace with a
@@ -84,11 +84,11 @@ moves the \fiber object\\
 \begin{tabular}{ l l }
     \midrule
 
-    \cpp{fiber\_handle& operator=(fiber\_handle&& other) noexcept} & (1)\\
+    \cpp{fiber\_context& operator=(fiber\_context&& other) noexcept} & (1)\\
 
     \midrule
 
-    \cpp{fiber\_handle& operator=(const fiber\_handle& other)=delete} & (2)\\
+    \cpp{fiber\_context& operator=(const fiber\_context& other)=delete} & (2)\\
 
     \midrule
 \end{tabular}
@@ -110,7 +110,7 @@ moves the \fiber object\\
 
 {\bfseries Postcondition}
 \begin{description}
-    \item[1)] \cpp{other} is invalidated (\opbool returns \cpp{false})
+    \item[1)] \cpp{other} is invalidated (\cpp{valid()} returns \cpp{false})
 \end{description}
 
 
@@ -120,21 +120,21 @@ resumes a fiber\\
 \begin{tabular}{ l l }
     \midrule
 
-    \cpp{fiber\_handle resume() &&} & (1)\\
+    \cpp{fiber\_context resume() &&} & (1)\\
 
     \midrule
 
     \cpp{template<typename Fn>}\\
-    \cpp{fiber\_handle resume\_with(Fn&& fn) &&} & (2)\\
+    \cpp{fiber\_context resume\_with(Fn&& fn) &&} & (2)\\
 
     \midrule
 
-    \cpp{fiber\_handle resume\_from\_any\_thread() &&} & (3)\\
+    \cpp{fiber\_context resume\_from\_any\_thread() &&} & (3)\\
 
     \midrule
 
     \cpp{template<typename Fn>}\\
-    \cpp{fiber\_handle resume\_from\_any\_thread\_with(Fn&& fn) &&} & (4)\\
+    \cpp{fiber\_context resume\_from\_any\_thread\_with(Fn&& fn) &&} & (4)\\
 
     \midrule
 \end{tabular}
@@ -148,24 +148,28 @@ resumes a fiber\\
 
 {\bfseries Parameters}
 \begin{description}
-    \item[fn] function injected into resumed fiber\\
+    \item[fn] invokable injected into resumed fiber\\
+\end{description}
+
+{\bfseries Preconditions}
+\begin{description}
+    \item[1),2),3),4)] \cpp{*this} is valid (\cpp{valid()} returns \cpp{true})
+    \item[1),2)] the current \thread is the same as the thread on
+              which the fiber represented by \cpp{*this} was most recently run
 \end{description}
 
 {\bfseries Return value}
 \begin{description}
-    \item[fiber\_handle] the returned instance represents the fiber that has been
+    \item[fiber\_context] the returned instance represents the fiber that has been
                  suspended in order to resume the current fiber
 \end{description}
 
 {\bfseries Exceptions}
 \begin{description}
-    \item[1)] \resume or \resumewith might throw \cpp{std::domain\_error} if
-              the current \thread is not the same as the thread on
-              which \cpp{*this} was most recently run
-    \item[2)] \resume, \resumewith, \xtresume or \xtresumewith might throw\\
-              \unwindex if, while suspended, the \fiber instance representing
+    \item[1)] \resume, \resumewith, \xtresume or \xtresumewith throws\\
+              \unwindex when, while suspended, the \fiber instance representing
               the suspended fiber is destroyed
-    \item[3)] \resume, \resumewith, \xtresume or \xtresumewith might
+    \item[2)] \resume, \resumewith, \xtresume or \xtresumewith can
               throw \emph{any} exception if, while suspended:
               \begin{itemize}
                   \item some other fiber calls \resumewith or \xtresumewith to
@@ -174,7 +178,7 @@ resumes a fiber\\
                         or \xtresumewith -- or some function called
                         by \cpp{fn} -- throws an exception
               \end{itemize}
-    \item[4)] Any exception thrown by the function \cpp{fn} passed
+    \item[3)] Any exception thrown by the function \cpp{fn} passed
               to \resumewith or \xtresumewith, or any function called
               by \cpp{fn}, is thrown in the fiber referenced by \cpp{*this}
               rather than in the fiber of the caller of \resumewith
@@ -183,7 +187,7 @@ resumes a fiber\\
 
 {\bfseries Preconditions}
 \begin{description}
-    \item[1)] \cpp{*this} represents a valid fiber (\opbool returns \cpp{true})
+    \item[1)] \cpp{*this} represents a valid fiber (\cpp{valid()} returns \cpp{true})
     \item[2)] for \resume and \resumewith, the current \thread is the same as
               the thread on which \cpp{*this} was most recently run
     \item[3)] for \resume, \resumewith, \xtresume and \xtresumewith, if\\
@@ -193,7 +197,7 @@ resumes a fiber\\
 
 {\bfseries Postcondition}
 \begin{description}
-    \item[1)] \cpp{*this} is invalidated (\opbool returns \cpp{false})
+    \item[1)] \cpp{*this} is invalidated (\cpp{valid()} returns \cpp{false})
 \end{description}
 
 {\bfseries Notes}
@@ -214,9 +218,9 @@ last resumed on the calling thread.\\
 \resume, \resumewith, \xtresume and \xtresumewith preserve the execution
 context of the calling fiber. Those data are restored if the calling fiber is
 resumed.\\
-A suspended \cpp{fiber\_handle} can be destroyed. Its resources will be cleaned
+A suspended \cpp{fiber\_context} can be destroyed. Its resources will be cleaned
 up at that time.\\
-The returned \cpp{fiber\_handle} indicates via \opbool whether the previous active
+The returned \cpp{fiber\_context} indicates via \cpp{valid()} whether the previous active
 fiber has terminated (returned from \entryfn).\\
 Because \resume, \resumewith, \xtresume and \xtresumewith invalidate the
 instance on which they are called, \emph{no valid \fiber instance ever
@@ -227,7 +231,7 @@ newly-invalidated instance -- the instance on which the method was was called
 -- with the new instance returned by that call. This helps to avoid subsequent
 inadvertent attempts to resume the old, invalidated instance.
 \newline
-An injected function \cpp{fn()} must accept \cpp{std::fiber\_handle&&} and
+An injected function \cpp{fn()} must accept \cpp{std::fiber\_context&&} and
 return \fiber. It will be passed a synthesized \fiber instance representing
 the suspended caller of \resumewith or\\
 \xtresumewith. The \fiber instance returned by \cpp{fn()} is, in turn, used as
@@ -249,14 +253,10 @@ stack, and the calling thread is not that thread.\\
 \end{tabular}
 
 \begin{description}
-    \item[1)] \cpp{fiber\_handle::can\_resume\_from\_any\_thread()} returns \cpp{false}
+    \item[1)] \cpp{fiber\_context::can\_resume\_from\_any\_thread()} returns \cpp{false}
+        if \cpp{*this} does not represent a valid fiber, or
         if the stack used by the fiber was provided by the operating system,
         and the calling thread is not that thread; otherwise \cpp{true}.
-\end{description}
-
-{\bfseries Precondition}
-\begin{description}
-    \item[1)] \cpp{*this} represents a valid fiber (\opbool returns \cpp{true})
 \end{description}
 
 {\bfseries Notes}
@@ -289,15 +289,11 @@ by \resume, \resumewith, \xtresume or \xtresumewith.\\
 \end{tabular}
 
 \begin{description}
-    \item[1)] returns \cpp{true} if the calling thread is the same as the
+    \item[1)] returns \cpp{true} if \cpp{*this} represents a valid fiber,
+        and the calling thread is the same as the
         thread on which \cpp{*this} was suspended. If the \fiber has not yet
         run and has therefore never been suspended, returns \cpp{true} as
         well.
-\end{description}
-
-{\bfseries Precondition}
-\begin{description}
-    \item[1)] \cpp{*this} represents a valid fiber (\opbool returns \cpp{true})
 \end{description}
 
 {\bfseries Notes}
@@ -305,13 +301,17 @@ by \resume, \resumewith, \xtresume or \xtresumewith.\\
 \canresume is not marked \cpp{const} because in at least one
 implementation, it requires an internal context switch.
 
-\subparagraph*{operator bool}
+\subparagraph*{valid()}
 test whether \fiber is valid\\
 
 \begin{tabular}{ l l }
     \midrule
 
-    \cpp{explicit operator bool() const noexcept} & (1)\\
+    \cpp{bool valid() const noexcept} & (1)\\
+
+    \midrule
+
+    \cpp{explicit operator bool() const noexcept} & (2)\\
 
     \midrule
 \end{tabular}
@@ -319,6 +319,7 @@ test whether \fiber is valid\\
 \begin{description}
     \item[1)] returns \cpp{true} if \cpp{*this} represents a fiber of
               execution, \cpp{false} otherwise.
+    \item[2)] alias for \cpp{valid()}
 \end{description}
 
 {\bfseries Notes}
@@ -343,33 +344,13 @@ The essential points:
 \end{itemize}
 
 
-\subparagraph*{(comparisons)}
-establish an arbitrary total ordering for \fiber instances\\
-
-\begin{tabular}{ l l }
-    \midrule
-
-    \cpp{bool operator<(const fiber\_handle& other) const noexcept} & (1)\\
-
-    \midrule
-\end{tabular}
-
-\begin{description}
-    \item[1)] This comparison establishes an arbitrary total ordering of \fiber
-              instances, for example to store in ordered containers. (However,
-              key lookup is meaningless, since you cannot construct a search key
-              that would compare equal to any valid entry.) There is no significance
-              to the relative order of two instances.
-\end{description}
-
-
 \subparagraph*{swap}
 swaps two \fiber instances\\
 
 \begin{tabular}{ l l }
     \midrule
 
-    \cpp{void swap(fiber\_handle& other) noexcept} & (1)\\
+    \cpp{void swap(fiber\_context& other) noexcept} & (1)\\
 
     \midrule
 \end{tabular}
@@ -388,7 +369,7 @@ be called from any function on that fiber.\\
 \begin{tabular}{ l l }
     \midrule
 
-    \cpp{void unwind\_fiber(fiber\_handle&& other)} & (1)\\
+    \cpp{[[ noreturn ]] void unwind\_fiber(fiber\_context&& other)} & (1)\\
 
     \midrule
 \end{tabular}
@@ -406,7 +387,7 @@ be called from any function on that fiber.\\
 
 \bfs{Preconditions}
 \begin{description}
-    \item[1)] \cpp{other} must be valid (\cpp{operator bool()} returns \cpp{true})
+    \item[1)] \cpp{other} must be valid (\cpp{valid()} returns \cpp{true})
 \end{description}
 
 \bfs{Return value}

--- a/code/assign_resumewith.cpp
+++ b/code/assign_resumewith.cpp
@@ -1,11 +1,11 @@
 class filament{
 private:
-    fiber_handle       f_;
+    fiber_context       f_;
 
 public:
     ...
     void resume_next( filament& fila){
-        std::move(fila.f_).resume_with([this](fiber_handle&& f)->fiber_handle{
+        std::move(fila.f_).resume_with([this](fiber_context&& f)->fiber_context{
             f_=std::move(f);
             return {};
         }

--- a/code/asymmetric_op.cpp
+++ b/code/asymmetric_op.cpp
@@ -1,15 +1,15 @@
-fiber_handle f4{[]{
+fiber_context f4{[]{
     self::suspend();
 };
-fiber_handle f3{[&f4]{
+fiber_context f3{[&f4]{
     f4.resume();
     self::suspend();
 }};
-fiber_handle f2{[&f3]{
+fiber_context f2{[&f3]{
     f3.resume();
     self::suspend();
 }};
-fiber_handle f1{[&f2]{
+fiber_context f1{[&f2]{
     f2.resume();
     self::suspend();
 }};

--- a/code/fiber.cpp
+++ b/code/fiber.cpp
@@ -1,28 +1,28 @@
-class fiber_handle {
+class fiber_context {
 public:
-    fiber_handle() noexcept;
+    fiber_context() noexcept;
 
     template<typename Fn>
-    explicit fiber_handle(Fn&& fn);
+    explicit fiber_context(Fn&& fn);
 
-    ~fiber_handle();
+    ~fiber_context();
 
-    fiber_handle(fiber_handle&& other) noexcept;
-    fiber_handle& operator=(fiber_handle&& other) noexcept;
-    fiber_handle(const fiber_handle& other) noexcept = delete;
-    fiber_handle& operator=(const fiber_handle& other) noexcept = delete;
+    fiber_context(fiber_context&& other) noexcept;
+    fiber_context& operator=(fiber_context&& other) noexcept;
+    fiber_context(const fiber_context& other) noexcept = delete;
+    fiber_context& operator=(const fiber_context& other) noexcept = delete;
 
-    fiber_handle resume() &&;
+    fiber_context resume() &&;
     template<typename Fn>
-    fiber_handle resume_with(Fn&& fn) &&;
-    fiber_handle resume_from_any_thread() &&;
+    fiber_context resume_with(Fn&& fn) &&;
+    fiber_context resume_from_any_thread() &&;
     template<typename Fn>
-    fiber_handle resume_from_any_thread_with(Fn&& fn) &&;
+    fiber_context resume_from_any_thread_with(Fn&& fn) &&;
 
     bool can_resume() noexcept;
     bool can_resume_from_any_thread() noexcept;
 
     explicit operator bool() const noexcept;
-    bool operator<(const fiber_handle& other) const noexcept;
-    void swap(fiber_handle& other) noexcept;
+    bool valid() const noexcept;
+    void swap(fiber_context& other) noexcept;
 };

--- a/code/generator.cpp
+++ b/code/generator.cpp
@@ -1,5 +1,5 @@
 int a;
-std::fiber_handle g{[&a](std::fiber_handle&& m){
+std::fiber_context g{[&a](std::fiber_context&& m){
     a=0;
     int b=1;
     for(;;){

--- a/code/initial_resume_with.cpp
+++ b/code/initial_resume_with.cpp
@@ -1,6 +1,6 @@
-fiber_handle topfunc(fiber_handle&& prev);
-fiber_handle injected(fiber_handle&& prev);
+fiber_context topfunc(fiber_context&& prev);
+fiber_context injected(fiber_context&& prev);
 
-fiber_handle f(topfunc);
+fiber_context f(topfunc);
 // topfunc() has not yet been entered
 std::move(f).resume_with(injected);

--- a/code/multi_current.cpp
+++ b/code/multi_current.cpp
@@ -1,3 +1,3 @@
-fiber_handle f1=fiber_handle::current();
-fiber_handle f2=fiber_handle::current();
+fiber_context f1=fiber_context::current();
+fiber_context f2=fiber_context::current();
 assert(f1==f2); // f1 and f2 point to the same (active) fiber

--- a/code/ontop.cpp
+++ b/code/ontop.cpp
@@ -1,5 +1,5 @@
 int data = 0;
-fiber_handle f{[&data](fiber_handle&& m){
+fiber_context f{[&data](fiber_context&& m){
     std::cout << "f1: entered first time: " << data  << std::endl;
     data+=1;
     m=std::move(m).resume();
@@ -15,7 +15,7 @@ data+=1;
 f=std::move(f).resume();
 std::cout << "f1: returned second time: " << data << std::endl;
 data+=1;
-f=std::move(f).resume_with([&data](fiber_handle&& m){
+f=std::move(f).resume_with([&data](fiber_context&& m){
     std::cout << "f2: entered: " << data << std::endl;
     data=-1;
     return std::move(m);

--- a/code/passing_lambda.cpp
+++ b/code/passing_lambda.cpp
@@ -1,5 +1,5 @@
 int i=1;
-std::fiber_handle lambda{[&i](fiber_handle&& caller){
+std::fiber_context lambda{[&i](fiber_context&& caller){
     std::cout << "inside lambda,i==" << i << std::endl;
     i+=1;
     caller=std::move(caller).resume();

--- a/code/resume_current.cpp
+++ b/code/resume_current.cpp
@@ -1,2 +1,2 @@
-fiber_handle m=fiber_handle::current();
+fiber_context m=fiber_context::current();
 m.resume(); // tries to resume active fiber == UB

--- a/code/return_from_resume_inplace.cpp
+++ b/code/return_from_resume_inplace.cpp
@@ -1,6 +1,6 @@
 int main(){
-    fiber_handle f1,f2,f3;
-    f3=fiber_handle{[&](fiber_handle&& f)->fiber_handle{
+    fiber_context f1,f2,f3;
+    f3=fiber_context{[&](fiber_context&& f)->fiber_context{
         f2=std::move(f);
         for(;;){
             std::cout << "f3 ";
@@ -8,7 +8,7 @@ int main(){
         }
         return {};
     }};
-    f2=fiber_handle{[&](fiber_handle&& f)->fiber_handle{
+    f2=fiber_context{[&](fiber_context&& f)->fiber_context{
         f1=std::move(f);
         for(;;){
             std::cout << "f2 ";
@@ -16,7 +16,7 @@ int main(){
         }
         return {};
     }};
-    f1=fiber_handle{[&](fiber_handle&& /*main*/)->fiber_handle{
+    f1=fiber_context{[&](fiber_context&& /*main*/)->fiber_context{
         for(;;){
             std::cout << "f1 ";
             std::move(f2).resume();

--- a/code/return_from_resume_invalid.cpp
+++ b/code/return_from_resume_invalid.cpp
@@ -1,6 +1,6 @@
 int main(){
-    fiber_handle f1,f2,f3;
-    f3=fiber_handle{[&](fiber_handle&& f)->fiber_handle{
+    fiber_context f1,f2,f3;
+    f3=fiber_context{[&](fiber_context&& f)->fiber_context{
         f2=std::move(f);
         for(;;){
             std::cout << "f3 ";
@@ -8,7 +8,7 @@ int main(){
         }
         return {};
     }};
-    f2=fiber_handle{[&](fiber_handle&& f)->fiber_handle{
+    f2=fiber_context{[&](fiber_context&& f)->fiber_context{
         f1=std::move(f);
         for(;;){
             std::cout << "f2 ";
@@ -16,7 +16,7 @@ int main(){
         }
         return {};
     }};
-    f1=fiber_handle{[&](fiber_handle&& /*main*/)->fiber_handle{
+    f1=fiber_context{[&](fiber_context&& /*main*/)->fiber_context{
         for(;;){
             std::cout << "f1 ";
             f3=std::move(f2).resume();

--- a/code/return_to_main.cpp
+++ b/code/return_to_main.cpp
@@ -1,5 +1,5 @@
 int main() {
-    fiber_handle f{[]{
+    fiber_context f{[]{
         ...
         // switch to `main()` only by returning
     }};

--- a/code/static_current.cpp
+++ b/code/static_current.cpp
@@ -1,7 +1,7 @@
 int main(){
     int a;
-    fiber_handle m=fiber_handle::current(); // get active fiber
-    fiber_handle f{[&]{
+    fiber_context m=fiber_context::current(); // get active fiber
+    fiber_context f{[&]{
         a=0;
         int b=1;
         for(;;){

--- a/code/suspender.cpp
+++ b/code/suspender.cpp
@@ -1,10 +1,10 @@
-fiber_handle f([](fiber_handle&& caller){
+fiber_context f([](fiber_context&& caller){
     // ...
     std::move(caller).resume();
     // ...
 });
 
-fiber_handle fn(fiber_handle&&);
+fiber_context fn(fiber_context&&);
 
 f = std::move(f).resume();
 // ...

--- a/code/symmetric_op.cpp
+++ b/code/symmetric_op.cpp
@@ -1,14 +1,14 @@
-fiber_handle* pf1;
-fiber_handle f4{[&pf1]{
+fiber_context* pf1;
+fiber_context f4{[&pf1]{
     pf1->resume();
 };
-fiber_handle f3{[&f4]{
+fiber_context f3{[&f4]{
     f4.resume();
 }};
-fiber_handle f2{[&f3]{
+fiber_context f2{[&f3]{
     f3.resume();
 }};
-fiber_handle f1{[&f2]{
+fiber_context f1{[&f2]{
     f2.resume();
 }};
 pf1=&f1;

--- a/code/synthesized_foo.cpp
+++ b/code/synthesized_foo.cpp
@@ -1,5 +1,5 @@
 void foo(){
-    fiber_handle f{[](fiber_handle&& m){
+    fiber_context f{[](fiber_context&& m){
         m=std::move(m).resume(); // switch to `foo()`
         m=std::move(m).resume(); // switch to `foo()`
         ...

--- a/code/synthesized_main.cpp
+++ b/code/synthesized_main.cpp
@@ -1,5 +1,5 @@
 int main(){
-    fiber_handle f{[](fiber_handle&& m){
+    fiber_context f{[](fiber_context&& m){
         m=std::move(m).resume(); // switch to `main()`
         ...
     }};

--- a/code/terminating_fiber.cpp
+++ b/code/terminating_fiber.cpp
@@ -1,5 +1,5 @@
 int main(){
-    fiber_handle f{[](fiber_handle&& m){
+    fiber_context f{[](fiber_context&& m){
         return std::move(m); // resume `main()` by returning `m`
     }};
     std::move(f).resume(); // resume `f`

--- a/code/terminating_fiber_complex.cpp
+++ b/code/terminating_fiber_complex.cpp
@@ -1,11 +1,11 @@
 int main(){
-    fiber_handle m;
-    fiber_handle f1{[&](fiber_handle&& f){
+    fiber_context m;
+    fiber_context f1{[&](fiber_context&& f){
         std::cout << "f1: entered first time" << std::endl;
         assert(!f);
         return std::move(m); // resume (main-)fiber that has started `f2`
     }};
-    fiber_handle f2{[&](fiber_handle&& f){
+    fiber_context f2{[&](fiber_context&& f){
         std::cout << "f2: entered first time" << std::endl;
         m=std::move(f); // preserve `f` (== suspended main())
         return std::move(f1);

--- a/commands.tex
+++ b/commands.tex
@@ -74,6 +74,9 @@
 \newcommand{\canresume}{\cpp{can\_resume()}}
 \newcommand{\canxtresume}{\cpp{can\_resume\_from\_any\_thread()}}
 \newcommand{\thread}{\cpp{std::thread}}
+\newcommand{\Currthread}{The calling thread}
+\newcommand{\currthread}{the calling thread}
+\newcommand{\lastthread}{the thread on which the fiber represented by \cpp{*this} was most recently run}
 \newcommand{\unwindex}{\cpp{std::unwind\_exception}}
 \newcommand{\unwindfib}{\cpp{std::unwind\_fiber()}}
 

--- a/commands.tex
+++ b/commands.tex
@@ -74,8 +74,8 @@
 \newcommand{\canresume}{\cpp{can\_resume()}}
 \newcommand{\canxtresume}{\cpp{can\_resume\_from\_any\_thread()}}
 \newcommand{\thread}{\cpp{std::thread}}
-\newcommand{\Currthread}{The calling thread}
-\newcommand{\currthread}{the calling thread}
+\newcommand{\Currthread}{The calling thread\xspace}
+\newcommand{\currthread}{the calling thread\xspace}
 \newcommand{\lastthread}{the thread on which the fiber represented by \cpp{*this} was most recently run}
 \newcommand{\unwindex}{\cpp{std::unwind\_exception}}
 \newcommand{\unwindfib}{\cpp{std::unwind\_fiber()}}

--- a/commands.tex
+++ b/commands.tex
@@ -62,9 +62,9 @@
         stringstyle=\ttfamily\color{magenta}
 ] {code/#1.cpp}}
 
-\newcommand{\dtor}{\cpp{\~fiber\_handle()}}
+\newcommand{\dtor}{\cpp{\~fiber\_context()}}
 \newcommand{\main}{\cpp{main()}}
-\newcommand{\fiber}{\cpp{std::fiber\_handle}}
+\newcommand{\fiber}{\cpp{std::fiber\_context}}
 \newcommand{\op}{\cpp{operator()()}}
 \newcommand{\opbool}{\cpp{operator bool()}}
 \newcommand{\resume}{\cpp{resume()}}

--- a/problem_gp_ub.tex
+++ b/problem_gp_ub.tex
@@ -45,7 +45,7 @@ applications (for instance generators).
 
 But this solution requires an internal global variable pointing to the active
 fiber and some kind of reference counting. Reference counting is needed because
-\cpp{fiber\_handle::current()} necessarily requires multiple instances of \fiber for the
+\cpp{fiber\_context::current()} necessarily requires multiple instances of \fiber for the
 active fiber. Only when the last reference goes out of scope can the fiber be
 destroyed and its stack deallocated.
 \cppf{multi_current}

--- a/references.tex
+++ b/references.tex
@@ -44,6 +44,10 @@
         \href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0876r2.pdf}
         {P0876R2: fibers without scheduler}
 
+    \bibitem{P0876R3}
+        \href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0876r3.pdf}
+        {P0876R3: fibers without scheduler}
+
     \bibitem{coreguidlines}
         \href{http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Ri-global}
         {C++ Core Guidelines}

--- a/resume_with.tex
+++ b/resume_with.tex
@@ -11,7 +11,7 @@ fiber \cpp{f} as if the \resume call at line 3 had directly
 called \cpp{fn()}.\\
 
 Like an \entryfn\xspace passed to \fiber, \cpp{fn()} must accept
-\cpp{std::fiber\_handle&&} and return\\
+\cpp{std::fiber\_context&&} and return\\
 \fiber. The \fiber instance returned by \cpp{fn()} will, in turn, be returned
 to \cpp{f}'s lambda by the \resume at line 3.\\
 
@@ -22,7 +22,7 @@ Suppose further that after doing some work (line 4), the lambda calls
 \cpp{m.resume()}, thereby switching back to the main fiber. The lambda remains
 suspended in the call to \cpp{m.resume()} at line 5.\\
 At line 18 the main fiber calls \cpp{f.resume\_with()} where the passed lambda
-accepts \cpp{fiber\_handle &&}. That new lambda is called on the fiber of the suspended
+accepts \cpp{fiber\_context &&}. That new lambda is called on the fiber of the suspended
 lambda. It is as if the \cpp{m.resume()} call at line 8 directly called the second
 lambda.\\
 

--- a/solution_gp_ub.tex
+++ b/solution_gp_ub.tex
@@ -77,7 +77,7 @@ internal global variables that point to \main is to explicitly return a valid
 \cppfl{terminating_fiber}
 
 In line 5 the fiber is started by invoking \resume on instance \cpp{f}. \main
-is suspended and an instance of type \cpp{fiber\_handle} is synthesized and passed as
+is suspended and an instance of type \cpp{fiber\_context} is synthesized and passed as
 parameter \cpp{m} to the lambda at line 2. The fiber terminates by returning
 \cpp{m}. Control is transferred to \main (returning from \cpp{f.resume()} at
 line 5) while fiber \cpp{f} is destroyed.\\
@@ -99,7 +99,7 @@ the captured \fiber\xspace \cpp{m} as return value (line 6). Control is returned
 \main, returning from \cpp{f2.resume()} at line 13.\\
 
 \zs{The function passed to \fiber's constructor must have
-signature `\cpp{fiber\_handle(fiber\_handle&&)}`. Using \fiber as the return
+signature `\cpp{fiber\_context(fiber\_context&&)}`. Using \fiber as the return
 value from such a function avoids global variables.}
 
 \uabschnitt{returning synthesized \fiber instance from \cpp{resume()}}\label{fiberreturn}

--- a/termination.tex
+++ b/termination.tex
@@ -18,7 +18,7 @@ Therefore, any of the following will gracefully terminate a fiber:
     \item From within the fiber you wish to terminate, construct and
           throw \unwindex, binding the \fiber you intend to resume next. This
           is what \unwindfib does internally.
-    \item Call \cpp{fiber\_handle::resume\_with(unwind\_fiber)}. This is what \dtor
+    \item Call \cpp{fiber\_context::resume\_with(unwind\_fiber)}. This is what \dtor
           does. Since\\\unwindfib accepts a \fiber, and since \resumewith
           synthesizes a\\\fiber representing its caller and passes it to the
           subject function, this terminates the fiber referenced by the


### PR DESCRIPTION
Most of the edits are the mechanical replacements of `fiber_handle` to `fiber_context`.

Other changes are summarized in the updated Revision History.