### PR TITLE
Start reformatting API for constructor, destructor

### DIFF
--- a/P0876R5.tex
+++ b/P0876R5.tex
@@ -60,7 +60,7 @@
 \small
 \begin{tabbing}
     Document number: \= P0876R5\\
-    Date:            \> 2019-01-16\\
+    Date:            \> 2019-01-17\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> LEWG, LEWGI\\

--- a/api.tex
+++ b/api.tex
@@ -96,52 +96,43 @@ constructs new \cpp{fiber\_context}\\
     \item[1)] this constructor instantiates an invalid \fiber. Its \cpp{valid()} method
               returns \cpp{false}.
     \item[2)] takes an invocable (function, lambda, object with \op) as
-              argument. The invocable must have signature as described
-              in \nameref{solution_gpub}.
-              This constructor template shall not participate in overload
-              resolution unless \cpp{Fn} is \emph{LvalueCallable} (23.14.13.2)
-              for the argument type \cpp{std::fiber\_context&&} and the return
-              type \fiber.
+              argument. The invocable must have signature \cpp{fiber\_context
+              fn(fiber\_context&&)}. This constructor template shall not
+              participate in overload resolution unless \cpp{Fn}
+              is \emph{LvalueCallable} (23.14.13.2) for the argument
+              type \cpp{std::fiber\_context&&} and the return type \fiber.
+              \tsnote{The entry-function \cpp{fn} is \emph{not} immediately
+              entered. The stack and any other necessary resources are created
+              on construction, but \cpp{fn} is not entered
+              until \resume, \resumewith, \xtresume or \xtresumewith is
+              called.} \tsnote{The entry-function \cpp{fn} passed to \fiber
+              will be passed a synthesized \fiber instance representing the
+              suspended caller of \resume, \resumewith, \xtresume or\\
+              \xtresumewith.}
     \item[3)] moves underlying state to new \fiber
     \item[4)] copy constructor deleted
 \end{description}
 
-{\bfseries Notes}
+\dtor
+
+\emph{Effects:}
 \begin{description}
-    \item The entry-function \cpp{fn} is \emph{not} immediately entered. The
-          stack and any other necessary resources are created on construction,
-          but \cpp{fn} is not entered until \resume, \resumewith, \xtresume or\\
-          \xtresumewith is called.
-    \item The entry-function \cpp{fn} passed to \fiber will be passed a
-          synthesized \fiber instance representing the suspended caller
-          of \resume, \resumewith, \xtresume or\\
-          \xtresumewith.
-\end{description}
-
-\subparagraph*{(destructor)}\label{destructor}
-destroys a fiber\\
-
-\begin{tabular}{ l l }
-    \midrule
-
-    \dtor & (1)\\
-
-    \midrule
-\end{tabular}
-
-\begin{description}
-    \item[1)] destroys a \fiber instance. If this instance represents a fiber
+    \item[--] destroys a \fiber instance. If this instance represents a fiber
               of execution (\cpp{valid()} returns \cpp{true}), then the fiber of
               execution is destroyed too. Specifically, the stack is unwound
-              by throwing \unwindex.\footnote{ In a program in which exceptions
-              are thrown, it is prudent to code a fiber's \entryfn\xspace with a
+              by throwing \unwindex.
+\end{description}
+
+\emph{Remarks:}
+\begin{description}
+    \item[--] In a program in which exceptions
+              are thrown, it is prudent to code a fiber's \entryfn\ with a
               last-ditch \cpp{catch (...)} clause: in general, exceptions must
               \emph{not} leak out of the \entryfn. However, since stack
               unwinding is implemented by throwing an exception, a correct
               \entryfn\ \cpp{try} statement must also
-              \cpp{catch (std::unwind\_exception const&)} and rethrow it.}
+              \cpp{catch (std::unwind\_exception const&)} and rethrow it.
 \end{description}
-
 
 \subparagraph*{operator=}
 moves the \fiber object\\

--- a/code/synopsis.cpp
+++ b/code/synopsis.cpp
@@ -1,5 +1,7 @@
 #include <fiber_context>
 
+#define __cpp_lib_experimental_fiber_context 201902
+
 namespace std {
 namespace experimental {
 inline namespace concurrency_v2 {

--- a/commands.tex
+++ b/commands.tex
@@ -97,6 +97,8 @@
 \newcommand{\tsuabschnitt}[1]{\subsubsection[]{#1}}
 \newcommand{\tsparagraph}[1]{\paragraph[]{#1}}
 
+\newcommand{\tsnote}[1]{[ \emph{Note:} {#1} -- \emph{end note} ]}
+
 \newcommand{\bcontext}{
         \href{http://www.boost.org/doc/libs/release/libs/context/doc/html/index.html}
         {\emph{Boost.Context}}}


### PR DESCRIPTION
I added \tsnote{...} to generate the [ *Note:* ... -- *end note* ] syntax favored by the Standard.

I was trying for the *Effects:* ... *Remarks:* ... formatting exemplified in the [Concurrency TS v1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0159r0.html), but my \emph{Effects:} ... \item[--] guess doesn't really produce the effect I want. Can you set up formatting to look like the TS?