### PR TITLE
Mostly finished editing round, proofreading still pending.

### DIFF
--- a/P0876R6.tex
+++ b/P0876R6.tex
@@ -60,7 +60,7 @@
 \small
 \begin{tabbing}
     Document number: \= P0876R6\\
-    Date:            \> 2019-04-05\\
+    Date:            \> 2019-06-10\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> SG1\\
@@ -74,15 +74,7 @@
 
 %//////////////////////////////////////////////////////////////////////////////
 
-\abschnitt{Revision History}
-This document supersedes P0876R5.\\
-\newline
-Changes since P0876R5:
-
-%\begin{itemize}
-%    \item
-%\end{itemize}
-
+\input{history}
 \input{abstract}
 \input{control_transfer}
 \input{first_class}
@@ -94,7 +86,7 @@ Changes since P0876R5:
 \input{passing_data}
 \input{termination}
 \input{exceptions}
-\input{stack}
+%%\input{stack}
 \input{low_level}
 \input{stl}
 \input{implementation}

--- a/abstract.tex
+++ b/abstract.tex
@@ -1,4 +1,4 @@
-\abschnitt{abstract}
+\abschnitt{abstract}\label{abstract}
 
 This paper addresses concerns, questions and suggestions from the past meetings.
 The proposed API supersedes the former proposals N3985\cite{N3985},
@@ -10,11 +10,6 @@ in the context of \cpp{future::then()}, the committee has indicated
 that \emph{fiber} is preferable. However, given the foundational, low-level
 nature of this proposal, we choose \emph{fiber\_context}, leaving the
 term \emph{fiber} for a higher-level facility built on top of this one.\\
-
-A previous revision of this proposal suggested \emph{fiber\_context}, but SG1
-felt that use of the term ``context'' posed potential confusion. The name 
-\emph{basic\_fiber} has also been suggested. Consider that the name is not yet
-final.\\
 
 The minimal API enables stackful context switching \bfs{without} the need for a
 \bfs{scheduler}. The API is suitable to act as building-block for high-level

--- a/acknowledgment.tex
+++ b/acknowledgment.tex
@@ -1,4 +1,4 @@
-\abschnitt{acknowledgment}
+\abschnitt{acknowledgments}
 
 The authors would like to thank Andrii Grynenko, Detlef Vollmann, Geoffrey Romer,
 Grigory Demchenko, Lee Howes, David Hollman, Eric Fiselier and Yedidya Feldblum.

--- a/api.tex
+++ b/api.tex
@@ -26,9 +26,9 @@ fiber.
 Suspending the running fiber in order to resume (or launch) another is
 called \emph{context switching}.
 
-The term ``thread'' here means that even though a given fiber may suspend and
-later be resumed, it is logically a thread of execution as defined in
-[intro.multithread].
+The term ``thread'' in ``cooperative user-mode thread'' means that even
+though a given fiber may suspend and later be resumed, it is logically a
+thread of execution as defined in [intro.multithread].
 
 Launching a fiber logically creates a new function stack, which remains
 associated with that fiber throughout its lifetime. Calling functions on a
@@ -38,24 +38,51 @@ and returns on any other fiber.
 Context switching can be effected by designating some other fiber's stack as
 current, in a manner appropriate to the implementation of function stacks.
 
+\rSec3[fiber-context.empty]{Empty vs. Non-Empty}
+
+A \fiber instance may be \emph{empty} or \emph{non-empty}. A
+default-constructed \fiber is empty. A moved-from \fiber is empty. A \fiber
+representing a suspended fiber is non-empty.
+
+\rSec3[fiber-context.implicit]{Explicit Fiber vs. Implicit Fiber}
+
+It is convenient to take the position that every kernel thread in a program,
+including the default thread on which the program runs \main, has an initial
+\emph{default fiber} whose stack is allocated by the host operating system. Thus,
+when \main instantiates a new \fiber, it becomes the second fiber on
+that thread.
+
+Upon resumption of a fiber, a non-empty \fiber instance is passed in
+representing the newly-suspended previous fiber. This \fiber instance might
+represent the thread's default fiber, or it might represent an
+explicitly-launched fiber: a fiber explicitly instantiated by
+invoking \fiber's constructor.
+
+In certain situations it is important to distinguish these two cases. In
+particular, it is Undefined Behavior to attempt to resume a thread's default
+fiber on some other thread. We use the phrase \emph{explicit fiber}
+or \emph{explicitly-launched fiber} to designate a fiber instantiated by user
+code; conversely, \emph{implicit fiber} designates the default fiber on any
+thread.
+
 \rSec3[fiber-context.toplevel]{Implicit Top-Level Stack Frame}
 
-When a fiber is explicitly launched by invoking \fiber's constructor, the
-facility injects an implicit top-level stack frame above the \entryfn passed to
-the constructor. If the fiber is later unwound, this implicit top-level stack
-frame serves as delimiter: this point is where unwinding stops.
+On every explicit fiber, the facility injects an implicit top-level stack
+frame above the \entryfn passed to the constructor. If the fiber is later
+unwound, this implicit top-level stack frame serves as delimiter: this point
+is where unwinding stops.
 
 Unwinding requires a non-empty \fiber instance indicating the fiber to which
 control should subsequently be passed. Once the terminated fiber's stack has
 been fully unwound, the implicit top-level function resumes the indicated fiber.
 
-Similarly, the runtime must pass control through an implicit top-level
-function above \main and above the \entryfn for each explicitly
-launched \thread. The stack frame delimits stack unwinding for each of these
+Similarly, on every implicit fiber, the runtime must pass control through an
+implicit top-level function above \main and above the \entryfn for
+each \thread. The stack frame delimits stack unwinding for each of these
 stacks.
 
-However, the top-level function above \main and each \thread must destroy
-the \fiber instance indicating the fiber that triggered stack unwinding.
+However, the top-level function for an implicit fiber must destroy
+the \fiber instance representing the fiber that triggered stack unwinding.
 
 \rSec3[fiber-context.synopis]{Header <experimental/fiber\_context> synopsis}
 
@@ -90,24 +117,33 @@ constructs new \cpp{fiber\_context}\\
 \end{tabular}
 
 \begin{description}
-    \item[1)] this constructor instantiates an invalid \fiber. Its \cpp{valid()} method
-              returns \cpp{false}.
-    \item[2)] takes a callable object [func.def] as
-              argument. The callable must have signature \cpp{fiber\_context
+    \item[1)] this constructor instantiates an empty \fiber. Its \cpp{empty()} method
+              returns \cpp{true}.
+    \item[2)] takes a invocable object [func.def] as
+              argument. The invocable must have signature \cpp{fiber\_context
               fn(fiber\_context&&)}. This constructor template shall not
               participate in overload resolution unless \cpp{Fn}
-              is \emph{Lvalue-Callable} [func.wrap.func] for the argument
-              type \cpp{std::fiber\_context&&} and the return type \fiber.
-              \tsnote{The entry-function \cpp{fn} is \emph{not} immediately
-              entered. The stack and any other necessary resources are created
-              on construction, but \cpp{fn} is not entered
-              until \resume, \resumewith, \xtresume or \xtresumewith is
-              called.} \tsnote{The entry-function \cpp{fn} passed to \fiber
-              will be passed a synthesized \fiber instance representing the
-              suspended caller of \resume, \resumewith, \xtresume or
-              \xtresumewith.}
+              is \emph{Lvalue-Invocable} [func.wrap.func] for the argument
+              type \cpp{std::fiber\_context&&} and the return type \fiber.\\
+              \bfs{SG1:} Needs update to \cpp{Invocable} idiom.
     \item[3)] moves underlying state to new \fiber
     \item[4)] copy constructor deleted
+\end{description}
+
+\remarks
+\begin{description}
+    \item[---] The entry-function \cpp{fn} is \emph{not} immediately
+              entered. The stack and any other necessary resources are created
+              on construction, but \cpp{fn} is not entered
+              until \allresume is called.
+    \item[---] A newly constructed but not yet entered fiber may be resumed by
+              any thread. For any explicit fiber, the thread that resumes it
+              is constrained only by the last thread that previously resumed
+              it -- and that constraint is imposed by operations performed by
+              the fiber, rather than by the \fiber facility itself.
+    \item[---] The entry-function \cpp{fn} passed to \fiber
+              will be passed a synthesized \fiber instance representing the
+              suspended caller of \allresume.
 \end{description}
 
 \mbrhdr{\~fiber\_context()}
@@ -115,19 +151,20 @@ constructs new \cpp{fiber\_context}\\
 \effects
 \begin{description}
     \item[---] destroys a \fiber instance. If this instance represents a fiber
-              of execution (\cpp{valid()} returns \cpp{true}), then the fiber of
+              of execution (\cpp{empty()} returns \cpp{false}), then the fiber of
               execution is destroyed too.
 \end{description}
 
 \remarks
 \begin{description}
-    \item[---] Destroying a suspended fiber causes its stack to be unwound as
-               if the destructor called \cpp{resume\_with(unwind\_fiber)}.
+    \item[---] Destroying a suspended fiber causes its stack to be unwound --
+               equivalent to calling \cpp{resume\_with(unwind\_fiber)}.
     \item[---] The destructors of the stack variables on the suspended fiber
-               represented by \cpp{*this}, and relevant \cpp{catch (...)}
-               clauses, are run on the thread calling \dtor.
+               represented by \cpp{*this}
+%%, and relevant \catchall clauses,
+               are run on the thread calling \dtor.
     \item[---] As a consequence, destroying a \fiber instance
-               representing \main or the \entryfn of a \thread from some other
+               representing an implicit fiber from some other
                thread engages Undefined Behavior.
 \end{description}
 
@@ -164,7 +201,7 @@ moves the \fiber object\\
 
 \postcond
 \begin{description}
-    \item[---] \cpp{other} is invalidated (\cpp{valid()} returns \cpp{false})
+    \item[---] \cpp{other} is made empty (\cpp{empty()} returns \cpp{true})
 \end{description}
 
 
@@ -195,19 +232,51 @@ resumes a fiber\\
 
 \effects
 \begin{description}
-    \item[1),3)] suspends the active fiber, resumes fiber \cpp{*this}
-    \item[2),4)] suspends the active fiber, resumes fiber \cpp{*this}
-              but calls \cpp{fn()} in the resumed fiber (as if called by the
-              suspended function)
-              These member function templates shall not participate in overload
-              resolution unless \cpp{Fn} is \emph{Lvalue-Callable} [func.wrap.func]
+    \item[1),3)]
+        \begin{description}
+            \item[---] The calling fiber is suspended.
+            \item[---] A new \fiber instance representing the suspended caller
+                       is synthesized. For purposes of exposition, call
+                       it \cpp{caller}.
+            \item[---] The fiber represented by \cpp{*this} is resumed.
+            \item[---] If this is the first entry to the fiber represented
+                       by \cpp{*this}, \cpp{caller} is passed to its \entryfn.
+            \item[---] Otherwise, the fiber represented by \cpp{*this}
+                       previously suspended by calling one
+                       of \allresume. \cpp{caller} is returned from whichever
+                       of the \cpp{resume} functions was called.
+        \end{description}
+    \item[2),4)] These member function templates shall not participate in overload
+              resolution unless \cpp{Fn} is \emph{Lvalue-Invocable} [func.wrap.func]
               for the argument type \cpp{std::fiber\_context&&} and the return
-              type \fiber.
+              type \fiber.\\
+              \bfs{SG1:} Needs update to \cpp{Invocable} idiom.
+        \begin{description}
+            \item[---] The calling fiber is suspended.
+            \item[---] A new \fiber instance representing the suspended caller
+                       is synthesized. For purposes of exposition, call
+                       it \cpp{caller}.
+            \item[---] The fiber represented by \cpp{*this} is resumed.
+            \item[---] Function \cpp{fn} is called on the newly-resumed fiber.
+            \item[---] \cpp{caller} is passed to \cpp{fn}.
+            \item[---] If \cpp{fn} throws an exception, the exception
+                       propagates on the newly-resumed fiber.
+            \item[---] Otherwise \cpp{fn} eventually returns a \fiber
+                       instance, which may or may not be the same
+                       as \cpp{caller}. For purposes of exposition, call
+                       it \cpp{returned}.
+            \item[---] If this is the first entry to the fiber represented
+                       by \cpp{*this}, \cpp{returned} is passed to its \entryfn.
+            \item[---] Otherwise, the fiber represented by \cpp{*this}
+                       previously suspended by calling one
+                       of \allresume. \cpp{returned} is returned from whichever
+                       of the \cpp{resume} functions was called.
+        \end{description}
 \end{description}
 
 \params
 \begin{description}
-    \item[fn] callable object injected into resumed fiber
+    \item[fn] invocable object injected into resumed fiber
 \end{description}
 
 \returns
@@ -218,140 +287,135 @@ resumes a fiber\\
 
 \except
 \begin{description}
-%   \item[---] \resume, \resumewith, \xtresume or \xtresumewith throws\\
+%   \item[---] \allresume throws
 %             \unwindex when, while suspended, the \fiber instance representing
 %             the suspended fiber is destroyed
-    \item[---] \resume, \resumewith, \xtresume or \xtresumewith can
+    \item[---] \allresume can
               throw \emph{any} exception if, while suspended:
               \begin{itemize}
-                  \item some other fiber calls \resumewith or \xtresumewith to
+                  \item some other fiber calls \someresumewith to
                         resume this suspended fiber
-                  \item the function \cpp{fn} passed to \resumewith
-                        or \xtresumewith -- or some function called
+                  \item the function \cpp{fn} passed to \someresumewith
+                        -- or some function called
                         by \cpp{fn} -- throws an exception
               \end{itemize}
     \item[---] Any exception thrown by the function \cpp{fn} passed
-              to \resumewith or \xtresumewith, or any function called
+              to \someresumewith, or any function called
               by \cpp{fn}, is thrown in the fiber referenced by \cpp{*this}
-              rather than in the fiber of the caller of \resumewith
-              or \xtresumewith.
+              rather than in the fiber of the caller of \someresumewith.
 \end{description}
 
 \requires
 \begin{description}
-    \item[---] \cpp{*this} represents a valid fiber (\cpp{valid()} returns \cpp{true})
-    \item[---] for \resume and \resumewith, \currthread is the same as
+    \item[---] \cpp{*this} represents a non-empty fiber (\cpp{empty()} returns \cpp{false})
+    \item[---] for \resumesome, \currthread is the same as
               \lastthread
-    \item[---] for \resume, \resumewith, \xtresume and \xtresumewith, if\\
+    \item[---] for \allresume, if\\
               \canxtresume would return \cpp{false}, \currthread is
               the same as \lastthread
 \end{description}
 
 \postcond
 \begin{description}
-    \item[---] \cpp{*this} is invalidated (\cpp{valid()} returns \cpp{false})
+    \item[---] \cpp{*this} is made empty (\cpp{empty()} returns \cpp{true})
 \end{description}
 
-\remarks
-\newline
-The intent of the distinction between \resume and \xtresume, as
+\tsnote{The intent of the distinction between \resume and \xtresume, as
 between \resumewith and \xtresumewith, is both for validation and for code
-auditing. If an application only ever calls \resume and \resumewith, no fiber
+auditing. If an application only ever calls \resumesome, no fiber
 will ever be resumed on a thread other than the one on which it was initially
-resumed.
+resumed.}
 
-The intent of the names \xtresume and \xtresumewith is to clarify the
+\tsnote{The intent of the names \xtresume and \xtresumewith is to clarify the
 direction in which cross-thread resumption occurs. \Currthread always
 directly resumes a suspended fiber: control is passed into the suspended
 fiber, and the currently-running fiber suspends. These method names mean that
 the fiber represented by \cpp{*this} will be resumed whether or not it was
-last resumed on \currthread.
+last resumed on \currthread.}
 
-\resume, \resumewith, \xtresume and \xtresumewith preserve the execution
+\tsnote{\allresume preserve the execution
 context of the calling fiber. Those data are restored if the calling fiber is
-resumed.
+resumed.}
 
-A suspended \cpp{fiber\_context} can be destroyed. Its resources will be cleaned
-up at that time.
+\tsnote{A suspended \cpp{fiber\_context} can be destroyed. Its resources will be cleaned
+up at that time.}
 
-The returned \cpp{fiber\_context} indicates via \cpp{valid()} whether the previous active
-fiber has terminated (returned from \entryfn).
+\tsnote{The returned \cpp{fiber\_context} indicates via \cpp{empty()} whether the previous active
+fiber has terminated (returned from \entryfn).}
 
-Because \resume, \resumewith, \xtresume and \xtresumewith invalidate the
-instance on which they are called, \emph{no valid \fiber instance ever
-represents the currently-running fiber.} In order to express the invalidation
-explicitly, these methods are rvalue-reference qualified.
+\tsnote{Because \allresume empties the
+instance on which it is called, \emph{no non-empty \fiber instance ever
+represents the currently-running fiber.} In order to express the state change
+explicitly, these methods are rvalue-reference qualified.}
 
-When calling any of these methods, it is conventional to replace the
-newly-invalidated instance -- the instance on which the method was was called
+\tsnote{When calling any of these methods, it is conventional to replace the
+newly-emptied instance -- the instance on which the method was was called
 -- with the new instance returned by that call. This helps to avoid subsequent
-inadvertent attempts to resume the old, invalidated instance.
+inadvertent attempts to resume the old, empty instance.}
 
-An injected function \cpp{fn()} must have signature
+\tsnote{An injected function \cpp{fn()} must have signature
 \cpp{std::fiber\_context fn(std::fiber\_context&&)}.
 It will be passed a synthesized \fiber instance representing
-the suspended caller of \resumewith or\\
-\xtresumewith. The \fiber instance returned by \cpp{fn()} is, in turn, used as
-the return value for the suspended function: \resume, \resumewith, \xtresume
-or\\\xtresumewith.
+the suspended caller of \someresumewith.
+The \fiber instance returned by \cpp{fn()} is, in turn, used as
+the return value for the suspended function: \allresume.}
 
-\mbrhdr{bool can\_resume\_from\_any\_thread() noexcept}
+\mbrhdr{bool can\_resume\_from\_this\_thread() noexcept}
 
 \effects
 query whether \currthread can resume the suspended\\
-\fiber instance by
-calling \xtresume or \xtresumewith. The implementation must return \cpp{false}
-if the suspended \fiber instance represents a fiber with a system-provided
-stack, and \currthread is not that thread.\\
+\fiber instance by calling \xtresumesome. The implementation must
+return \cpp{false} if the suspended \fiber instance represents an implicit
+fiber, and \currthread is not that thread.\\
 
 \returns
 \begin{description}
-    \item[---] \cpp{fiber\_context::can\_resume\_from\_any\_thread()} returns \cpp{false}
-        if \cpp{*this} does not represent a valid fiber, or
-        if the stack used by the fiber was provided by the operating system,
+    \item[---] \cpp{fiber\_context::can\_resume\_from\_this\_thread()} returns \cpp{false}
+        if \cpp{*this} is empty, or
+        if it represents an implicit fiber,
         and \currthread is not that thread; otherwise \cpp{true}.
 \end{description}
 
 \remarks
 \begin{description}
-    \item[---] When \main, or the entry-function of a \thread, or any function
-        directly called by these, is suspended, a \fiber instance represents that
+    \item[---] When an implicit fiber is suspended, a \fiber instance represents that
         suspended fiber. You may resume that suspended fiber \emph{on the same thread}
-        using any of \resume, \resumewith, \xtresume or \xtresumewith. Attempting to
+        using any of \allresume. Attempting to
         resume that suspended fiber from any other thread is Undefined Behavior.
     \item[---] \canxtresume returns \cpp{true} if \currthread is the same as \lastthread,
-        or if the \fiber instance
-        represents a fiber explicitly created by \fiber's constructor.
+        or if the \fiber instance represents an explicit fiber.
     \item[---] \canxtresume is not marked \cpp{const} because in at least one
-        implementation, it requires an internal context switch.
+        implementation, it requires an internal context switch. However, the
+        stack operations are effectively read-only. Nonetheless, if it is
+        possible for more than one thread to call \canxtresume concurrently on
+        the same non-empty \fiber instance, locking is the caller's responsibility.
 \end{description}
 
 \mbrhdr{bool can\_resume() noexcept}
 
 \returns
-\cpp{true} if \currthread is the same as \lastthread,
-or if \cpp{*this} has not yet been resumed. When \canresume
-returns \cpp{true}, the\\
-\fiber instance may be resumed
-by \resume, \resumewith, \xtresume or \xtresumewith.\\
+\cpp{false} if \cpp{*this} is empty, or if \currthread is not the same
+as \lastthread. \tsnote{When \canresume returns \cpp{true}, the\\ \fiber
+instance may be resumed by \allresume.}\\
 
 \remarks
 \begin{description}
-    \item[---] returns \cpp{true} if \cpp{*this} represents a valid fiber,
-        and \currthread is the same as \lastthread. If the \fiber has not yet
-        run and has therefore never been suspended, returns \cpp{true} as
-        well.
+    \item[---] returns \cpp{false} if \cpp{*this} is empty,
+        or if \currthread is not the same as \lastthread. Otherwise returns \cpp{true}.
     \item[---] \canresume is not marked \cpp{const} because in at least one
-        implementation, it requires an internal context switch.
+        implementation, it requires an internal context switch. However, the
+        stack operations are effectively read-only. Nonetheless, if it is
+        possible for more than one thread to call \canxtresume concurrently on
+        the same non-empty \fiber instance, locking is the caller's responsibility.
 \end{description}
 
-\subparagraph*{valid()}
-test whether \fiber is valid\\
+\subparagraph*{empty()}
+test whether \fiber is empty\\
 
 \begin{tabular}{ l l }
     \midrule
 
-    \cpp{bool valid() const noexcept} & (1)\\
+    \cpp{bool empty() const noexcept} & (1)\\
 
     \midrule
 
@@ -362,22 +426,12 @@ test whether \fiber is valid\\
 
 \returns
 \begin{description}
-    \item[1)] returns \cpp{true} if \cpp{*this} represents a fiber of
-              execution, \cpp{false} otherwise.
-    \item[2)] alias for \cpp{valid()}
+    \item[1)] returns \cpp{false} if \cpp{*this} represents a fiber of
+              execution, \cpp{true} otherwise.
+    \item[2)] equivalent to \cpp{(! empty())}
 \end{description}
 
-\tsnote{A \fiber instance might not represent a valid fiber for any of a number of reasons.
-\begin{itemize}
-    \item It might have been default-constructed.
-    \item It might have been moved from.
-    \item It might already have been resumed -- calling \resume, \resumewith,
-          \xtresume or\\
-          \xtresumewith invalidates the instance.
-    \item The \entryfn might have voluntarily terminated the fiber by
-          returning.
-\end{itemize}
-The essential points:
+\tsnote{The essential points:
 \begin{itemize}
     \item Regardless of the number of \fiber declarations, exactly one\\
           \fiber instance represents each suspended fiber.
@@ -400,31 +454,31 @@ terminate the current running fiber.
 
 \remarks
 \begin{description}
-    \item[---] On an explicitly launched fiber, once the running fiber has
+    \item[---] On an explicit fiber, once the running fiber has
                been fully unwound, \unwindfib resumes the fiber represented
-               by \cpp{other}. This is like returning \cpp{other} from
+               by \cpp{other}. \tsnote{This is like returning \cpp{other} from
                the \entryfn, but may be called from any function on that
-               fiber.
-    \item[---] On the fiber running \main or the default fiber for a \thread,
-               once the running fiber has been fully unwound, \unwindfib
-               destroys the fiber represented by \cpp{other}.
+               fiber.}
+    \item[---] On an implicit fiber, once the running fiber has been fully
+               unwound, \unwindfib destroys the fiber represented
+               by \cpp{other}.
     \item[---] The underlying Unwinding facility (for instance unwind facility
                described in \emph{System V ABI for AMD64}) unwinds the stack
                to the implicit top-level stack frame and terminates the
                current fiber as described above.
     \item[---] Unwinding the fiber's stack causes its stack variables to be
                destroyed.
-    \item[---] Unwinding the fiber's stack causes relevant \cpp{catch (...)}
-               clauses to be executed.
-    \item[---] During this specific stack unwinding, a \cpp{catch (...)}
-               clause that does not execute a \cpp{throw;} statement behaves
-               as if it ended with a \cpp{throw;} statement.
-    \item[---] During this specific stack unwinding, a \cpp{catch (...)}
-               clause that attempts to throw any C++ exception engages
-               Undefined Behavior.
-    \item[---] During this specific stack unwinding, only \cpp{catch (...)}
-               clauses are executed. No other \cpp{catch} clauses are
-               executed.
+%%  \item[---] Unwinding the fiber's stack causes relevant \catchall
+%%             clauses to be executed.
+%%  \item[---] During this specific stack unwinding, a \catchall
+%%             clause that does not execute a \cpp{throw;} statement behaves
+%%             as if it ended with a \cpp{throw;} statement.
+%%  \item[---] During this specific stack unwinding, a \catchall
+%%             clause that attempts to throw any C++ exception engages
+%%             Undefined Behavior.
+    \item[---] During this specific stack unwinding, 
+%% only \catchall clauses are executed. No other
+               no \cpp{catch} clauses are executed, not even \catchall.
 \end{description}
 
 \params
@@ -434,7 +488,7 @@ terminate the current running fiber.
 
 \requires
 \begin{description}
-    \item[---] \cpp{other} must be valid (\cpp{valid()} returns \cpp{true})
+    \item[---] \cpp{other} must not be empty (\cpp{empty()} returns \cpp{false})
 \end{description}
 
 \returns

--- a/api.tex
+++ b/api.tex
@@ -30,35 +30,32 @@ The term ``thread'' here means that even though a given fiber may suspend and
 later be resumed, it is logically a thread of execution as defined in
 [intro.multithread].
 
-Every C++ function that has been called, but has neither returned nor
-suspended, requires some storage for its variables with automatic storage
-duration [basic.stc.auto]. Typically this storage also contains bookkeeping
-data such as the location of the function's most recent caller, to support
-the \cpp{return} statement [stmt.return]. This storage is called the
-function's \emph{activation record} or \emph{activation frame}.
-
-Activation frames for active functions are logically kept in a \emph{function
-stack}, or simply \emph{stack}, as discussed in Exceptions [except],
-particularly sections Constructors and destructors [except.ctor], Handling an
-exception [except.handle], The \cpp{std::terminate} function
-[except.terminate] and The \cpp{std::uncaught\_exceptions()} function
-[except.uncaught].
-
-The term ``stack'' simply means that each function call causes the called
-function to construct a new activation frame. Return from that function
-destroys that activation frame, in last-in-first-out fashion. Each recursive
-call to a function causes a new activation frame to be constructed even though
-its previous activation frame(s) still exist.
-
-The implementation of such a stack is implementation-dependent.
-
-Launching a fiber logically creates a new stack, which remains associated with
-that fiber throughout its lifetime. Calling functions on a particular fiber,
-and returning from them, is independent of function calls and returns on any
-other fiber.
+Launching a fiber logically creates a new function stack, which remains
+associated with that fiber throughout its lifetime. Calling functions on a
+particular fiber, and returning from them, is independent of function calls
+and returns on any other fiber.
 
 Context switching can be effected by designating some other fiber's stack as
 current, in a manner appropriate to the implementation of function stacks.
+
+\rSec3[fiber-context.toplevel]{Implicit Top-Level Stack Frame}
+
+When a fiber is explicitly launched by invoking \fiber's constructor, the
+facility injects an implicit top-level stack frame above the \entryfn passed to
+the constructor. If the fiber is later unwound, this implicit top-level stack
+frame serves as delimiter: this point is where unwinding stops.
+
+Unwinding requires a non-empty \fiber instance indicating the fiber to which
+control should subsequently be passed. Once the terminated fiber's stack has
+been fully unwound, the implicit top-level function resumes the indicated fiber.
+
+Similarly, the runtime must pass control through an implicit top-level
+function above \main and above the \entryfn for each explicitly
+launched \thread. The stack frame delimits stack unwinding for each of these
+stacks.
+
+However, the top-level function above \main and each \thread must destroy
+the \fiber instance indicating the fiber that triggered stack unwinding.
 
 \rSec3[fiber-context.synopis]{Header <experimental/fiber\_context> synopsis}
 
@@ -119,19 +116,19 @@ constructs new \cpp{fiber\_context}\\
 \begin{description}
     \item[---] destroys a \fiber instance. If this instance represents a fiber
               of execution (\cpp{valid()} returns \cpp{true}), then the fiber of
-              execution is destroyed too. Specifically, the stack is unwound
-              using \unwindfib.
+              execution is destroyed too.
 \end{description}
 
 \remarks
 \begin{description}
-    \item[---] In a program in which exceptions
-              are thrown, it is prudent to code a fiber's \entryfn\ with a
-              last-ditch \cpp{catch (...)} clause: in general, exceptions must
-              \emph{not} leak out of the \entryfn. However, since stack
-              unwinding is implemented by throwing an exception, a correct
-              \entryfn\ \cpp{try} statement must also
-              \cpp{catch (std::unwind\_exception const&)} and rethrow it.
+    \item[---] Destroying a suspended fiber causes its stack to be unwound as
+               if the destructor called \cpp{resume\_with(unwind\_fiber)}.
+    \item[---] The destructors of the stack variables on the suspended fiber
+               represented by \cpp{*this}, and relevant \cpp{catch (...)}
+               clauses, are run on the thread calling \dtor.
+    \item[---] As a consequence, destroying a \fiber instance
+               representing \main or the \entryfn of a \thread from some other
+               thread engages Undefined Behavior.
 \end{description}
 
 \subparagraph*{operator=}
@@ -317,7 +314,7 @@ stack, and \currthread is not that thread.\\
 
 \remarks
 \begin{description}
-    \item[---] When \cpp{main()}, or the entry-function of a \thread, or any function
+    \item[---] When \main, or the entry-function of a \thread, or any function
         directly called by these, is suspended, a \fiber instance represents that
         suspended fiber. You may resume that suspended fiber \emph{on the same thread}
         using any of \resume, \resumewith, \xtresume or \xtresumewith. Attempting to
@@ -377,7 +374,7 @@ test whether \fiber is valid\\
     \item It might already have been resumed -- calling \resume, \resumewith,
           \xtresume or\\
           \xtresumewith invalidates the instance.
-    \item The \entryfn\xspace might have voluntarily terminated the fiber by
+    \item The \entryfn might have voluntarily terminated the fiber by
           returning.
 \end{itemize}
 The essential points:
@@ -399,21 +396,40 @@ The essential points:
 \mbrhdr{[[ noreturn ]] void unwind\_fiber(fiber\_context&& other)}
 
 \effects
-terminate the current running fiber, switching to the fiber represented by
-the passed\\\fiber. This is like returning that \fiber from the \entryfn, but
-may be called from any function on that fiber.
+terminate the current running fiber.
 
 \remarks
 \begin{description}
+    \item[---] On an explicitly launched fiber, once the running fiber has
+               been fully unwound, \unwindfib resumes the fiber represented
+               by \cpp{other}. This is like returning \cpp{other} from
+               the \entryfn, but may be called from any function on that
+               fiber.
+    \item[---] On the fiber running \main or the default fiber for a \thread,
+               once the running fiber has been fully unwound, \unwindfib
+               destroys the fiber represented by \cpp{other}.
     \item[---] The underlying Unwinding facility (for instance unwind facility
                described in \emph{System V ABI for AMD64}) unwinds the stack
-               till the end of stack is reached and terminates the current fiber
-               by returning the bound \fiber.
+               to the implicit top-level stack frame and terminates the
+               current fiber as described above.
+    \item[---] Unwinding the fiber's stack causes its stack variables to be
+               destroyed.
+    \item[---] Unwinding the fiber's stack causes relevant \cpp{catch (...)}
+               clauses to be executed.
+    \item[---] During this specific stack unwinding, a \cpp{catch (...)}
+               clause that does not execute a \cpp{throw;} statement behaves
+               as if it ended with a \cpp{throw;} statement.
+    \item[---] During this specific stack unwinding, a \cpp{catch (...)}
+               clause that attempts to throw any C++ exception engages
+               Undefined Behavior.
+    \item[---] During this specific stack unwinding, only \cpp{catch (...)}
+               clauses are executed. No other \cpp{catch} clauses are
+               executed.
 \end{description}
 
 \params
 \begin{description}
-    \item[other] the \fiber to which to switch once the current fiber hasterminated
+    \item[other] the \fiber to which to switch once the current fiber has terminated
 \end{description}
 
 \requires
@@ -428,5 +444,5 @@ may be called from any function on that fiber.
 
 \except
 \begin{description}
-    \item[---] throws a foreign exception (not catchable by C++)
+    \item[---] None catchable by C++
 \end{description}

--- a/code/return_from_resume_inplace.cpp
+++ b/code/return_from_resume_inplace.cpp
@@ -1,5 +1,5 @@
 int main(){
-    fiber_context f1,f2,f3;
+    fiber_context f1,f2,f3, holder;
     f3=fiber_context{[&](fiber_context&& f)->fiber_context{
         f2=std::move(f);
         for(;;){
@@ -16,7 +16,10 @@ int main(){
         }
         return {};
     }};
-    f1=fiber_context{[&](fiber_context&& /*main*/)->fiber_context{
+    f1=fiber_context{[&](fiber_context&& main)->fiber_context{
+        // important not to destroy the fiber_context instance representing
+        // main()
+        holder = std::move(main);
         for(;;){
             std::cout << "f1 ";
             std::move(f2).resume();

--- a/commands.tex
+++ b/commands.tex
@@ -77,18 +77,25 @@
 \newcommand{\resumewith}{\cpp{resume\_with()}}
 \newcommand{\xtresume}{\cpp{resume\_from\_any\_thread()}}
 \newcommand{\xtresumewith}{\cpp{resume\_from\_any\_thread\_with()}}
+\newcommand{\someresume}{\resume or \xtresume}
+\newcommand{\someresumewith}{\resumewith or \xtresumewith}
+\newcommand{\resumesome}{\resume or \resumewith}
+\newcommand{\xtresumesome}{\xtresume or \xtresumewith}
+\newcommand{\allresume}{\resume, \resumewith, \xtresume or \xtresumewith}
 \newcommand{\canresume}{\cpp{can\_resume()}}
-\newcommand{\canxtresume}{\cpp{can\_resume\_from\_any\_thread()}}
+\newcommand{\canxtresume}{\cpp{can\_resume\_from\_this\_thread()}}
+\newcommand{\canresumesome}{\canresume or \canxtresume}
 \newcommand{\thread}{\cpp{std::thread}}
 \newcommand{\Currthread}{The calling thread\xspace}
 \newcommand{\currthread}{the calling thread\xspace}
-\newcommand{\lastthread}{the thread on which the fiber represented by \cpp{*this} was most recently run}
-%\newcommand{\unwindex}{\cpp{std::unwind\_exception}}
+\newcommand{\lastthread}{the thread on which the fiber represented by \cpp{*this} was most recently resumed}
+\newcommand{\unwindex}{\cpp{std::unwind\_exception}}
 \newcommand{\unwindfib}{\cpp{std::unwind\_fiber()}}
 \newcommand{\uwforced}{\cpp{_Unwind_ForcedUnwind()}}
 \newcommand{\curex}{\cpp{std::current_exception()}}
 \newcommand{\uncex}{\cpp{std::uncaught_exception()}}
 \newcommand{\uncexs}{\cpp{std::uncaught_exceptions()}}
+\newcommand{\catchall}{\cpp{catch (...)}}
 
 \newcommand{\sym}{\emph{symmetric}\xspace}
 \newcommand{\asym}{\emph{asymmetric}\xspace}

--- a/commands.tex
+++ b/commands.tex
@@ -92,10 +92,10 @@
 
 \newcommand{\sym}{\emph{symmetric}\xspace}
 \newcommand{\asym}{\emph{asymmetric}\xspace}
-\newcommand{\entryfn}{\emph{entry-function}}
+\newcommand{\entryfn}{\emph{entry-function}\xspace}
 \newcommand{\dbframe}{\emph{.debug\_frame}}
 \newcommand{\ehframe}{\emph{.eh\_frame}}
-\newcommand{\foreignex}{\emph{foreign exception}}
+\newcommand{\foreignex}{\emph{foreign exception}\xspace}
 
 \newcommand{\abschnitt}[1]{\addcontentsline{toc}{subsection}{#1}\subsection*{#1}}
 \newcommand{\uabschnitt}[1]{\paragraph*{#1}}

--- a/exceptions.tex
+++ b/exceptions.tex
@@ -1,6 +1,7 @@
 \abschnitt{exceptions}\label{exceptions}
 
-In general, if an uncaught exception escapes from the \entryfn,
-\cpp{std::terminate} is called. There is one exception: \foreignex. The \fiber
-facility internally uses \foreignex to clean up the stack of a suspended context
-being destroyed. Because this exception is an \foreignex it can not be catched.
+In general, if an uncaught exception escapes from a fiber's \entryfn,
+\cpp{std::terminate} is called. There is one exception: the \foreignex used to
+unwind fiber stacks. The \fiber facility internally uses this \foreignex to
+clean up the stack of a suspended fiber being destroyed. Because this
+exception is a \foreignex, it can not be caught.

--- a/history.tex
+++ b/history.tex
@@ -1,0 +1,31 @@
+\abschnitt{Revision History}\label{history}
+This document supersedes P0876R5.\\
+\newline
+Changes since P0876R5:
+
+\begin{itemize}
+    \item \cpp{std::unwind\_exception} removed: stack unwinding must be
+      performed by platform facilities.
+\end{itemize}
+
+The change to unwinding fiber stacks using an anonymous \foreignex not
+catchable by C++ \cpp{try} / \cpp{catch} blocks is in response to deep
+discussions in Kona 2019 of the surprisingly numerous problems surfaced by
+using an ordinary C++ exception for that purpose.
+
+Further information about the specific mechanism can be found in
+\nameref{unwinding} et ff.
+
+
+
+Solved issues:
+\begin{itemize}
+    \item exception had to bind a \fiber, \fiber is not copyable, but exceptions must be copyable
+    \item catching and discarding exceptions
+    \item extracting the \fiber and rethrowing the exception with a moved-from \fiber instance
+    \item catching and not rethrowing the unwind exception
+    \item C++ rule that throwing an exception during exception unwinding terminates the program, since destroying a \fiber no longer causes a C++ exception to be thrown
+    \item capturing the unwind exception with \cpp{std::exception_ptr} and migrating it to a different fiber -- or a different thread.
+    \item what happens when unwind exception is thrown on any thread's original stack (e.g. \main).
+\end{itemize}
+

--- a/history.tex
+++ b/history.tex
@@ -6,6 +6,12 @@ Changes since P0876R5:
 \begin{itemize}
     \item \cpp{std::unwind\_exception} removed: stack unwinding must be
       performed by platform facilities.
+    \item \cpp{fiber\_context::can\_resume\_from\_any\_thread()} renamed to
+      \canxtresume.
+    \item \cpp{fiber\_context::valid()} renamed to \cpp{empty()} with inverted
+      sense.
+    \item Material has been added concerning the top-level wrapper
+      logic governing each fiber.
 \end{itemize}
 
 The change to unwinding fiber stacks using an anonymous \foreignex not
@@ -16,16 +22,34 @@ using an ordinary C++ exception for that purpose.
 Further information about the specific mechanism can be found in
 \nameref{unwinding} et ff.
 
-
-
-Solved issues:
+Problems resolved by discarding \unwindex in favor of a non-C++ \foreignex:
 \begin{itemize}
-    \item exception had to bind a \fiber, \fiber is not copyable, but exceptions must be copyable
-    \item catching and discarding exceptions
-    \item extracting the \fiber and rethrowing the exception with a moved-from \fiber instance
-    \item catching and not rethrowing the unwind exception
-    \item C++ rule that throwing an exception during exception unwinding terminates the program, since destroying a \fiber no longer causes a C++ exception to be thrown
-    \item capturing the unwind exception with \cpp{std::exception_ptr} and migrating it to a different fiber -- or a different thread.
-    \item what happens when unwind exception is thrown on any thread's original stack (e.g. \main).
+    \item When unwinding a fiber stack, it is essential to know the subsequent
+          fiber to resume. \unwindex therefore bound a \fiber. \fiber is
+          move-only. But exceptions must be copyable.
+    \item It was possible to catch and discard \unwindex, with problematic
+          consequences for its bound \fiber. The new mechanism does not permit
+          that.
+    \item Similarly, it used to be possible to catch \unwindex but not rethrow it.
+    \item If we attempted to address the problem above by introducing a
+          \unwindex operation to extract the bound \fiber, it became possible
+          to rethrow the exception with an empty (moved-from) \fiber instance.
+    \item Throwing a C++ exception during C++ exception unwinding terminates
+          the program. But destroying a \fiber no longer causes a C++
+          exception to be thrown.
+    \item It is no longer possible to capture \unwindex with
+          \cpp{std::exception\_ptr} and migrate it to a different fiber -- or
+          a different thread.
 \end{itemize}
 
+We have also addressed what happens when a \fiber instance representing \main,
+or the default fiber on a \thread, is destroyed.
+
+Not yet addressed:
+
+\begin{itemize}
+    \item During stack unwinding, is an object's destructor allowed to resume
+      some other fiber?
+%%  \item During stack unwinding, is a \catchall block allowed to
+%%    resume some other fiber?
+\end{itemize}

--- a/implementation.tex
+++ b/implementation.tex
@@ -60,7 +60,7 @@ In other words, \resume acts on the level of a simple function invocation --
 with the same performance characteristics (in terms of CPU cycles).\\
 
 This technique is used in \bcontext\cite{bcontext} which acts as building block
-for \fbfibers and \bbquantum. The \fbfibers\xspace framework itself is the basis
+for \fbfibers\xspace and \bbquantum. The \fbfibers\xspace framework itself is the basis
 of many critical applications at Facebook, such as \fbmcrouter\cite{fbmcrouter}
 and some other Facebook services/libraries like ServiceRouter (routing framework
 for \fbthrift\cite{fbthrift}), Node API (graph ORM API for graph databases) ...

--- a/invalidation.tex
+++ b/invalidation.tex
@@ -7,9 +7,9 @@ frames (note, the stack is not copyable).  Resuming a terminated fiber will
 cause undefined behaviour because the stack might already be unwound (objects
 allocated on the stack were destroyed or the memory used as stack was already
 deallocated).\\
-As a consequence each call of \resume will invalidate the \fiber instance, i.e.
-no valid instance of \fiber represents the currently-running fiber.\\
-Whether a \fiber is valid or not can be tested with member function \opbool.\\
+As a consequence each call of \resume will empty the \fiber instance, therefore
+no instance of \fiber represents the currently-running fiber.\\
+Whether or not a \fiber is empty can be tested with member function \opbool.\\
 To make this more explicit, functions \resume, \resumewith, \xtresume
 and\\
 \xtresumewith are rvalue-reference qualified.

--- a/low_level.tex
+++ b/low_level.tex
@@ -49,9 +49,9 @@ ORM API for graph databases) ...\\
 \uabschnitt{Bloomber's \bbquantum}\cite{bbquantum} is a full-featured and
 powerful C++ framework that allows users to dispatch units of work (a.k.a.
 tasks) as coroutines and execute them concurrently using the 'reactor' pattern.
-Main features are support for streaming futures which allows faster processing
+Its main features are support for streaming futures which allows faster processing
 of large data sets, task prioritization, fast pre-allocated memory pools and
-parallel forEach and mapReduce functions.
+parallel \cpp{forEach} and \cpp{mapReduce} functions.
 \cppf{bbquantum}
 
 \bbquantum\xspace is used in large projects at Bloomberg.

--- a/passing_data.tex
+++ b/passing_data.tex
@@ -10,7 +10,7 @@ new fiber. The value is incremented by one, as shown at line 4. The expression
 within the lambda by \cpp{caller}).\\
 The call to \cpp{lambda.resume()} at line 10 resumes the lambda, returning from
 the \cpp{caller.resume()} call at line 5. The \fiber instance \cpp{caller}
-invalidated by the \resume call at line 5 is replaced with the new instance
+emptied by the \resume call at line 5 is replaced with the new instance
 returned by that same \resume call.\\
 Finally the lambda returns (the updated) \cpp{caller} at line 6, terminating its
 context.\\
@@ -19,7 +19,7 @@ Since the updated \cpp{caller} represents the fiber suspended by the call at
 line 10, control returns to \main.\\
 
 However, since context \cpp{lambda} has now terminated, the updated \cpp{lambda}
-is invalid. Its \opbool returns \cpp{false}.\\
+is empty. Its \opbool returns \cpp{false}.\\
 
 \zs{Using lambda capture is the preferred way to transfer data between two
 fibers; global pointers or a calling wrapper (such as \cpp{std::bind}) are

--- a/representation.tex
+++ b/representation.tex
@@ -1,5 +1,5 @@
 \abschnitt{representing \emph{main} and thread's \emph{entry-fn} as fiber}\lable{representation}
 
 \zs{Note, that \cpp{m} represents the suspended \main as a \fiber! This is a nice
-feature because \main and each thread's \entryfn\xspace are handled equivalently to
+feature because \main and each thread's \entryfn are handled equivalently to
 explicitly-created fibers.}\\

--- a/resume_with.tex
+++ b/resume_with.tex
@@ -61,7 +61,7 @@ a\\
 
 In this situation, \cpp{injected()} is called with a \fiber instance
 representing the caller of \resumewith. When \cpp{injected()} eventually
-returns that (or some other valid) \fiber instance, the returned\\
+returns that (or some other) \fiber instance, the returned\\
 \fiber instance is passed into \cpp{topfunc()} as its \cpp{prev} parameter.
 
 \zs{Member functions \resumewith and \xtresumewith allow you to inject a

--- a/resume_with.tex
+++ b/resume_with.tex
@@ -10,7 +10,7 @@ The \resumewith call at line 11 injects function \cpp{fn()} into
 fiber \cpp{f} as if the \resume call at line 3 had directly
 called \cpp{fn()}.\\
 
-Like an \entryfn\xspace passed to \fiber, \cpp{fn()} must accept
+Like an \entryfn passed to \fiber, \cpp{fn()} must accept
 \cpp{std::fiber\_context&&} and return\\
 \fiber. The \fiber instance returned by \cpp{fn()} will, in turn, be returned
 to \cpp{f}'s lambda by the \resume at line 3.\\

--- a/solution_gp_ub.tex
+++ b/solution_gp_ub.tex
@@ -12,15 +12,15 @@ fiber is first started, or returned from \resume).
 \cppfl{synthesized_foo}
 
 In the pseudo-code above the fiber \cpp{f} is started by invoking its member
-function \resume at line 7. This operation suspends \cpp{foo}, invalidates
+function \resume at line 7. This operation suspends \cpp{foo}, empties
 instance \cpp{f} and synthesizes a new \fiber\xspace \cpp{m} that is passed as parameter
 to the lambda of \cpp{f} (line 2).\\
-Invoking \cpp{m.resume()} (line 3) suspends the lambda, invalidates \cpp{m} and
+Invoking \cpp{m.resume()} (line 3) suspends the lambda, empties \cpp{m} and
 synthesizes a \fiber that is returned by \cpp{f.resume()} at line 7. The
 synthesized \fiber is assigned to \cpp{f}. Instance \cpp{f} now represents the
 suspended fiber running the lambda (suspended at line 3). Control is
 transferred from line 3 (lambda) to line 7 (\cpp{foo()}).\\
-Call \cpp{f.resume()} at line 8 invalidates \cpp{f} and suspends \cpp{foo()}
+Call \cpp{f.resume()} at line 8 empties \cpp{f} and suspends \cpp{foo()}
 again. A \fiber representing the suspended \cpp{foo()} is synthesized, returned
 from \cpp{m.resume()} and assigned to \cpp{m} at line 3. Control
 is transferred back to the lambda and instance \cpp{m} represents the suspended
@@ -60,7 +60,7 @@ thread's \entryfn to be represented as fibers. A \fiber
 representing \main or a thread's \entryfn can be handled like an
 explicitly created \fiber: it can passed to and returned from functions or
 stored in a container. When called on such an instance, \canxtresume indicates
-whether it is valid to call \xtresume or \xtresumewith on that instance.\\
+whether it is valid to call \xtresumesome on that instance.\\
 
 In the code snippet above the suspended \main is represented by instance
 \cpp{m} and could be stored in containers or managed just like \cpp{f}
@@ -72,7 +72,7 @@ explicitly created fibers.}
 
 \uabschnitt{fiber returns (terminates)} When a fiber returns (terminates), what
 should happen next? Which fiber should be resumed next? The only way to avoid
-internal global variables that point to \main is to explicitly return a valid
+internal global variables that point to \main is to explicitly return a non-empty
 \fiber instance that will be resumed after the active fiber terminates.
 \cppfl{terminating_fiber}
 
@@ -94,7 +94,7 @@ returns. Fiber \cpp{f2} uses \cpp{f1}, that was also captured by the lambda, as
 return value. Fiber \cpp{f2} terminates while fiber \cpp{f1} is resumed (entered
 the first time). The synthesized \fiber\xspace \cpp{f} passed into the lambda at line 3
 represents the terminated fiber \cpp{f2} (e.g. the calling fiber). Thus instance
-\cpp{f} is invalid as the assert statement verifies at line 5. Fiber \cpp{f1} uses
+\cpp{f} is empty as the assert statement verifies at line 5. Fiber \cpp{f1} uses
 the captured \fiber\xspace \cpp{m} as return value (line 6). Control is returned to
 \main, returning from \cpp{f2.resume()} at line 13.\\
 
@@ -103,7 +103,7 @@ signature `\cpp{fiber\_context(fiber\_context&&)}`. Using \fiber as the return
 value from such a function avoids global variables.}
 
 \uabschnitt{returning synthesized \fiber instance from \cpp{resume()}}\label{fiberreturn}
-An instance of \fiber remains invalid after return from \resume, \resumewith,
+An instance of \fiber remains empty after return from \resume, \resumewith,
 \xtresume or\\
 \xtresumewith -- the synthesized fiber is returned, instead of
 implicitly updating the\\\fiber instance on which \resume was called.\\
@@ -155,25 +155,25 @@ passing \emph{the target} \cpp{filament} instance to \emph{the running fiber's}
 \cpp{resume\_next()}.\\
 
 Running fiber A has an associated \cpp{filament} instance \cpp{filamentA},
-whose \fiber \cpp{f\_} is invalid -- because fiber A is running.\\
+whose \fiber \cpp{f\_} is empty -- because fiber A is running.\\
 
 Desiring to switch to suspended fiber B (with associated
 \cpp{filament} \cpp{filamentB}), running fiber A calls\\
 \cpp{filamentA.resume\_next(filamentB)}.\\
 
 \cpp{resume\_next()} calls \cpp{filamentB.f\_.resume\_with(<lambda>)}.
-This invalidates \cpp{filamentB.f\_} -- because fiber B is now running.\\
+This empties \cpp{filamentB.f\_} -- because fiber B is now running.\\
 
 The lambda binds \cpp{&filamentA} as \cpp{this}. Running on fiber B, it
 receives a \fiber instance representing the newly-suspended fiber A as its
 parameter \cpp{f}. It moves that \fiber instance to \cpp{filamentA.f\_}.\\
 
-The lambda then returns a default-constructed (therefore invalid) \fiber
-instance. That invalid instance is returned by the previously-suspended
+The lambda then returns a default-constructed (therefore empty) \fiber
+instance. That empty instance is returned by the previously-suspended
 \resumewith call in \cpp{filamentB.resume\_next()} -- which is fine because
 \cpp{resume\_next()} drops it on the floor anyway.\\
 
-Thus, the running fiber's associated \cpp{filament::f\_} is always invalid,
+Thus, the running fiber's associated \cpp{filament::f\_} is always empty,
 whereas the \cpp{filament} associated with each suspended fiber is continually
 updated with the \fiber instance representing that
 fiber.\footnote{\bfiber\cite{bfiber} uses this pattern for resuming user-land

--- a/solution_gp_ub.tex
+++ b/solution_gp_ub.tex
@@ -32,7 +32,7 @@ Class \cpp{symmetric_coroutine<>::yield_type} from N3985\cite{N3985} is
 \bfs{not} equivalent to the synthesized \fiber.\\
 \cpp{symmetric_coroutine<>::yield_type} does not represent the suspended context,
 instead it is a special representation of the same coroutine. Thus \main or
-the current thread's \entryfn\xspace can \bfs{not} be represented by \cpp{yield_type}
+the current thread's \entryfn can \bfs{not} be represented by \cpp{yield_type}
 (see next section \nameref{representation}).\\
 Because \cpp{symmetric_coroutine<>::yield_type()} yields back to the starting
 point, i.e. invocation of\\
@@ -44,7 +44,7 @@ or UB happens at resumption.\\
 \zs{This API is specified in terms of passing the suspended \fiber. A higher
 level layer can hide that by using private variables.}
 
-\uabschnitt{representing \emph{main()} and thread's \entryfn\xspace as fiber}\label{representation}
+\uabschnitt{representing \emph{main()} and thread's \entryfn as fiber}\label{representation}
 As shown in the previous section a synthesized fiber is created and passed
 into the resumed fiber as an instance of \fiber.\\
 \cppf{synthesized_main}
@@ -56,8 +56,8 @@ are not excluded; these can be used as targets too.\\
 created by the OS (\main stack; each thread's initial stack) and some created
 explicitly by the code.}\\
 This is a nice feature because it allows (the stacks of) \main and each
-thread's \entryfn\xspace to be represented as fibers. A \fiber
-representing \main or a thread's \entryfn\xspace can be handled like an
+thread's \entryfn to be represented as fibers. A \fiber
+representing \main or a thread's \entryfn can be handled like an
 explicitly created \fiber: it can passed to and returned from functions or
 stored in a container. When called on such an instance, \canxtresume indicates
 whether it is valid to call \xtresume or \xtresumewith on that instance.\\
@@ -67,7 +67,7 @@ In the code snippet above the suspended \main is represented by instance
 by a scheduling algorithm.\\
 
 \zs{The proposed fiber API allows representing and handling \main and the
-current thread's \entryfn\xspace by an instance of \fiber in the same way as
+current thread's \entryfn by an instance of \fiber in the same way as
 explicitly created fibers.}
 
 \uabschnitt{fiber returns (terminates)} When a fiber returns (terminates), what
@@ -120,7 +120,7 @@ the next fiber (f1 -> f2 -> f3 -> f1 -> ...).\\
 Fiber \cpp{f1} is started at line 26. The synthesized \fiber\xspace \cpp{main} passed 
 to the resumed fiber is not used (control flow cycles through the three
 fibers).\footnote{The operating-system stack provided for \main or the current
-thread's \entryfn\xspace is not destroyed when the corresponding \fiber instance is
+thread's \entryfn is not destroyed when the corresponding \fiber instance is
 destroyed.}
 The for-loop prints the name \emph{f1} and resumes fiber \cpp{f2}. Inside 
 \cpp{f2}'s for-loop the name is printed and \cpp{f3} is resumed. Fiber \cpp{f3}

--- a/stack-def.tex
+++ b/stack-def.tex
@@ -1,0 +1,22 @@
+
+Every C++ function that has been called, but has neither returned nor
+suspended, requires some storage for its variables with automatic storage
+duration [basic.stc.auto]. Typically this storage also contains bookkeeping
+data such as the location of the function's most recent caller, to support
+the \cpp{return} statement [stmt.return]. This storage is called the
+function's \emph{activation record} or \emph{activation frame}.
+
+Activation frames for active functions are logically kept in a \emph{function
+stack}, or simply \emph{stack}, as discussed in Exceptions [except],
+particularly sections Constructors and destructors [except.ctor], Handling an
+exception [except.handle], The \cpp{std::terminate} function
+[except.terminate] and The \cpp{std::uncaught\_exceptions()} function
+[except.uncaught].
+
+The term ``stack'' simply means that each function call causes the called
+function to construct a new activation frame. Return from that function
+destroys that activation frame, in last-in-first-out fashion. Each recursive
+call to a function causes a new activation frame to be constructed even though
+its previous activation frame(s) still exist.
+
+The implementation of such a stack is implementation-dependent.

--- a/stack.tex
+++ b/stack.tex
@@ -1,8 +1,8 @@
 \abschnitt{stack destruction}\label{destruction}
 
-On construction of a \fiber a stack is allocated. If the \entryfn\xspace returns,
+On construction of a \fiber a stack is allocated. If the \entryfn returns,
 the stack will be destroyed. If the function has not yet returned and the
-\nameref{destructor} of the \fiber instance representing that context is called,
+destructor of the \fiber instance representing that context is called,
 the stack will be unwound and destroyed.\\
 
 Consider a running fiber \cpp{f2} that destroys the \fiber instance
@@ -12,17 +12,16 @@ representing \cpp{f1}.\\
 \resumewith, passing \unwindfib as
 argument. Fiber \cpp{f1} will be temporarily resumed and \unwindfib is
 invoked.\\
-Function \unwindfib binds an instance of \fiber that
-represents \cpp{f2}, then it unwinds \cpp{f1}'s stack
+Function \unwindfib caches an instance of \fiber that
+represents \cpp{f2}, then unwinds \cpp{f1}'s stack
 (walking the stack and destroying automatic variables in reverse order of
 construction).
 The first frame on \cpp{f1}'s stack, the one created by \fiber's constructor,
-catches the exception,
-extracts the bound \fiber representing \cpp{f2} and terminates \cpp{f1} by returning
+stops the unwinding. It terminates \cpp{f1} by returning
 \cpp{f2}. Control is returned to \cpp{f2} and \cpp{f1}'s
 stack gets deallocated.\\
 
-The stack on which \cpp{main()} is executed, as well as the stack implicitly
+The stack on which \main is executed, as well as the stack implicitly
 created by \thread's constructor, is allocated by the operating
 system. Such stacks are recognized by \fiber, and are not deallocated by its
 destructor.

--- a/termination.tex
+++ b/termination.tex
@@ -5,15 +5,15 @@ terminating the whole process, or engaging undefined behavior.\\
 
 When a \fiber instance is constructed with an \entryfn, its new stack is
 initialized with the frame of an implicit top-level function that marks the
-end of the stack. \unwindfib binds a \fiber instance, unwinds the stack
-till that top-level function and returns to the bound \fiber.\\
+end of the stack. \unwindfib unwinds the stack back to
+that top-level function, which returns to the \fiber passed to \unwindfib.\\
 
 Therefore, any of the following will gracefully terminate a fiber:
 
 \begin{itemize}
-    \item Cause its \entryfn\xspace to return a valid \fiber.
+    \item Cause its \entryfn to return a valid \fiber.
     \item From within the fiber you wish to terminate, call \unwindfib with a
-          valid \fiber. This binds the passed \fiber; that fiber will be resumed
+          valid \fiber. That fiber will be resumed
           when the active fiber terminates.
     \item Call \cpp{fiber\_context::resume\_with(unwind\_fiber)}. This is what \dtor
           does. Since\\\unwindfib accepts a \fiber, and since \resumewith
@@ -27,7 +27,7 @@ Therefore, any of the following will gracefully terminate a fiber:
 
 (However, since the operating system allocates the stack for \main and for a
 thread's \entryfn, of course there is no implicit top-level stack frame. In
-a conforming implementation, returning from a thread's \entryfn\xspace may
+a conforming implementation, returning from a thread's \entryfn may
 terminate all fibers on that thread. Returning from \main may terminate the
 whole process.)\\
 
@@ -39,9 +39,9 @@ terminate gracefully, by returning from its top-level function. You may not
 call \unwindfib. You may not call \dtor, explicitly or implicitly, on a
 valid \fiber instance.\\
 
-When an explicitly-launched fiber's \entryfn\xspace returns a valid \fiber
+When an explicitly-launched fiber's \entryfn returns a valid \fiber
 instance, that fiber is terminated. Control switches to the fiber indicated by
-the returned \fiber instance. The \entryfn\xspace may return (switch to) any
+the returned \fiber instance. The \entryfn may return (switch to) any
 reachable valid \fiber instance -- it need not be the instance originally
 passed in, or an instance returned from any of the \resume family of
 methods.\\
@@ -56,16 +56,17 @@ am suspending; please resume me later.''\\
 fiber; and by the way, I am done.''
 
 
-\uabschnitt{stack unwinding}
+\uabschnitt{stack unwinding}\label{unwinding}
 
-Stack unwinding caused by a exception, a thread termination or a fiber
-destruction exits functions without without normal return path. Local variables
-that go out of scope may have cleanup functions (destructors) that need to be called.
-The system needs to walk the stack and call the cleanup functions for each stack frame
-(e.g. for each local variable).\\
+Stack unwinding caused by an exception, thread termination or fiber
+destruction exits functions on that stack without executing a \cpp{return} statement. Local variables
+that go out of scope may have destructors that must be called.
+The implementation must walk the stack and call the destructor for each object
+in every such stack frame.\\
 
-C++ standard does not define how exception handling is implemented. Stack unwinding differs
-among different systems. The process of stack unwinding is described in the system ABI:
+The C++ standard does not define how exception handling is implemented. Stack unwinding differs
+among different systems. The process of stack unwinding is described in the
+system ABI, for instance:
 \begin{itemize}
     \item \emph{.eh\_frame}/\emph{personality routine} on SYS V AMD64 ABI\cite{SYSVAMD64} (de facto standard among Unix-like operating systems)
     \item \emph{RUNTIME\_FUNCTION}/\emph{UNWIND\_INFO} on x64 Windows\cite{WinX64}
@@ -76,58 +77,137 @@ among different systems. The process of stack unwinding is described in the syst
 is based on DWARF CFI (call frame information) that are stored in the \emph{.eh\_frame} section.
 Unwinding happens under following circumstances:
 \begin{itemize}
-    \item C++ exception has been thrown
-    \item unwinding forced by an external agent (as longjmp/fiber for instance)
+    \item A C++ exception has been thrown
+    \item unwinding is forced by an external agent (longjmp for instance)
 \end{itemize}
-\uwforced takes an \foreignex (non-C++ exception; for instance Java or GO) and walks the stack frame by frame
-inspecting the \emph{unwind tables} for cleanup functions (for instance destructor of
-local variables) and catch blocks. That is calling the personality routine
-(\cpp{__gxx_personality_v0()} for GCC)
-\footnote{The personality routine serves as interface between system unwinding library
-and language specific exception handling (not only C++; see GO and Java are support)
-is specific for an unwinding library. It is always referred via pointer (saved
-as function pointer in \ehframe for each stack frame).}
+\uwforced takes a \foreignex (non-C++ exception; for instance Java or GO) and walks the stack frame by frame
+inspecting the \emph{unwind tables} for cleanup functions (for instance destructors of
+local variables) and catch blocks.\\
+
+\uwforced calls a \emph{personality routine} (\cpp{__gxx_personality_v0()} forGCC)\footnote{The
+personality routine passed by a specific runtime serves as interface between system unwinding library
+and language specific exception handling (not only C++; GO and Java are also supported). It is always invoked via pointer (saved
+as a function pointer in \ehframe for each stack frame).}
 \uwforced takes a stop function that controls the termination of the unwinding
 (reaching end of stack for fibers).
 The stop function intercepts calls to the personality routine, letting the external
-agent override the defaults of the stack frame's personality routine.
-\footnote{As a consequence does the C++ personality routine deal only with C++ exceptions
-but it does not need to know anything specific about unwinding done on the external agent as fiber or pthreads cancellation.}
+agent override the defaults of the stack frame's personality routine.\footnote{As
+a consequence the C++ personality routine deals only with C++ exceptions;
+it does not need to know anything specific about unwinding done by an external
+agent such as fiber or pthreads cancellation.}
 When the destination frame (last frame on fiber
-stack) is entered the control is transferred back to the caller without returning.\\
+stack) is reached, control jumps back to the caller without literally returning.\\
 
-The code snipped below is a proof of concept available at \href{https://github.com/boostorg/context/tree/p0876r6}{Boost.Context branch p0876r6}.
+The code snippet below is a proof of concept available at \href{https://github.com/boostorg/context/tree/p0876r6}{Boost.Context branch p0876r6}.
 \cppf{unwind}
-\cpp{fiber_unwind()} is called by \unwindfib or \cpp{\~fiber()} and starts the stack unwinding.
-The foreign exception \cpp{foreign_unwind_ex}\footnote{setting member variable makes \cpp{foreign_unwind_ex} and foreign exception}
+\cpp{fiber_unwind()} is called by \unwindfib or \dtor and starts the stack unwinding.
+The foreign exception \cpp{foreign_unwind_ex}\footnote{setting member variable makes \cpp{foreign_unwind_ex} a foreign exception}
 is allocated and passed as parameter to the unwinding library. Function \cpp{fiber_unwind_stop()} transfers execution control
-to the calling fiber if the last stack frame has been unwound.
+to the calling fiber once the last stack frame has been unwound.
 
 \subparagraph{non-catchable \foreignex}
-\unwindfib uses an \foreignex to forced unwind as external agent.
+\unwindfib uses a non-C++ \foreignex to force stack unwinding.
 As stated in the \emph{SYS V AMD64 ABI}\cite{SYSVAMD64} standard:
 "A runtime is not allowed to catch an exception if the \cpp{_UA_FORCE_UNWIND} flag was passed to the personality routine."
 and "... since it is not possible to determine if a given catch clause will re-throw or not without executing it ...", the
 \foreignex must not be catchable by C++ \cpp{try-catch} blocks.\\
-As a consequence \curex can not return an \cpp{std::except_ptr} pointing to \foreignex.\\
-In order to detect if stack unwinding is currently in progress \uncex returns \cpp{true} and
+As a consequence, \curex can not return a \cpp{std::exception\_ptr} pointing to a \foreignex.\\
+In order to detect if stack unwinding is currently in progress \uncex returns \cpp{true} and\\
 \uncexs counts the \foreignex.\\
 
-Solved issues:
+The rationale for moving to an uncatchable exception is further explained in
+the \nameref{history}.\\
+
+The specific characteristics of a \foreignex:
+
 \begin{itemize}
-    \item exception had to bind a \fiber, \fiber is not copyable, but exceptions must be copyable
-    \item catching and discarding exceptions
-    \item extracting the \fiber and rethrowing the exception with a moved-from \fiber instance
-    \item catching and not rethrowing the unwind exception
-    \item C++ rule that throwing an exception during exception unwinding terminates the program, since destroying a \fiber no longer causes a C++ exception to be thrown
-    \item capturing the unwind exception with \cpp{std::exception_ptr} and migrating it to a different fiber -- or a different thread.
-    \item what happens when unwind exception is thrown on any thread's original stack (e.g. \cpp{main()}).
+    \item Throwing the \foreignex can only be effected by the \fiber
+    facility. The proposed \unwindfib is the only way to cause that
+    explicitly.
+    \item The ultimate "catch" -- the point at which stack unwinding stops --
+    is likewise determined by the \fiber facility. There is no explicit syntax
+    for this.
+    \item Along the way, as with a normal C++ exception, every object in every
+    stack frame is destroyed.
+    \item \cpp{catch (...)} clauses along the way are executed, but:
+    \begin{itemize}
+        \item \cpp{throw;} resumes stack unwinding, as usual
+        \item a \cpp{catch (...)} clause that does not execute a \cpp{throw;}
+        statement behaves as if it ends with a \cpp{throw;} statement
+        \item a \cpp{catch (...)} clause that attempts to throw a normal C++
+        exception engages Undefined Behavior
+    \end{itemize}
+    \item \cpp{catch (}\emph{anything else}\cpp{)} clauses along the way are ignored. This is
+    what is meant by the shorthand "uncatchable."
 \end{itemize}
 
-\subparagraph{destroying \fiber representing \cpp{main()}} is equivalent to terminating the application.
+Since unwinding a fiber's stack requires destroying objects declared in stack
+frames, and may involve executing \cpp{catch (...)} clauses, it is worth
+pointing out that destroying a non-empty \fiber on a thread other than the
+thread on which it was last resumed will run those object destructors
+and \cpp{catch (...)} clauses on the thread destroying the \fiber instance.\\
 
-\subparagraph{destroying \fiber representing \cpp{std::thread}} is equivalent to canceling the thread.
+As a consequence, destroying a \fiber instance representing \main or
+the initial stack of a \thread from any other thread engages Undefined
+Behavior.\footnote{One unobvious case would be if a fiber running on non-\main
+thread \cpp{T} stores a \fiber representing \cpp{T}'s default fiber in a static
+variable, whether module-scope or function-scope. That variable will be
+destroyed at program termination, probably on a thread other than \cpp{T}.}\\
 
-\zs{The systems exception handling, e.g. unwinding framework, is used to cleanup the stack
+Otherwise:
+
+\subparagraph{destroying a \fiber representing \main}\label{destroymain} is equivalent to terminating the application.
+
+The C++ runtime must inject a stack frame above \main that serves to stop
+stack unwinding due to the \foreignex. This is similar to, but different than,
+the stack frame above the \entryfn for an explicitly launched fiber.
+
+\unwindfib must always be called with a non-empty \fiber instance. That \fiber
+value is cached while the terminated fiber's stack is unwound.
+
+As its last act, the top-level stack frame on an explicitly launched fiber
+resumes the cached \fiber.
+
+In contrast, the stack frame injected above \main must finally \emph{destroy}
+the cached \fiber.
+
+It is not reasonable to unwind (e.g.) the stack belonging to \main to a
+certain point and then simply abandon it, leaving it unreachable.\footnote{A
+higher-level library built on this facility can introduce a scheduler. A
+scheduler could permit abandoning the \main fiber while continuing to run
+other fibers on the same thread; once the last of those fibers terminates, the
+scheduler can finally return from the \main fiber. But \fiber explicitly
+avoids introducing a scheduler.} Destroying the \fiber representing \main must
+end by returning to the runtime.
+
+Consider fiber F0: the default thread's default fiber, the fiber on
+which \main is called. F0 launches fiber F1, storing F1's \fiber in a
+stack variable, then launches F2. F2 destroys the \fiber instance representing
+F0.
+
+F0's stack is unwound with F2's \fiber instance cached.
+
+At some point along the way, the stack frame containing F1's \fiber is
+destroyed, thus F1's \fiber is destroyed. F0's stack unwinding is temporarily
+suspended and F1's stack is unwound. During this nested unwinding, F0's \fiber
+is cached.
+
+Once F1's stack is unwound -- because F1 was explicitly launched -- its
+implicit top-level function resumes F0's \fiber. This frees F1's stack memory
+and resumes unwinding F0's stack.
+
+Once F0's stack is unwound, as noted above, its top-level function must return
+to the runtime to terminate the process. However, F2 is still suspended at the
+point of destroying F0's (original) \fiber instance! F2's stack still exists!
+
+Therefore, F0's top-level function must destroy F2's cached \fiber instance
+before returning to the runtime.
+
+\subparagraph{destroying a \fiber representing \cpp{std::thread}} is
+equivalent to exiting the thread.
+
+The reasoning is the same as for the \fiber representing \main.
+
+\zs{The system's exception handling, i.e. its unwinding framework, is used to cleanup the stack
 of a fiber by using a foreign exception that is not catchable by C++ \cpp{try-catch} blocks.}
 

--- a/termination.tex
+++ b/termination.tex
@@ -11,9 +11,9 @@ that top-level function, which returns to the \fiber passed to \unwindfib.\\
 Therefore, any of the following will gracefully terminate a fiber:
 
 \begin{itemize}
-    \item Cause its \entryfn to return a valid \fiber.
+    \item Cause its \entryfn to return a non-empty \fiber.
     \item From within the fiber you wish to terminate, call \unwindfib with a
-          valid \fiber. That fiber will be resumed
+          non-empty \fiber. That fiber will be resumed
           when the active fiber terminates.
     \item Call \cpp{fiber\_context::resume\_with(unwind\_fiber)}. This is what \dtor
           does. Since\\\unwindfib accepts a \fiber, and since \resumewith
@@ -25,28 +25,22 @@ Therefore, any of the following will gracefully terminate a fiber:
           other fiber destroy the received \fiber instance.
 \end{itemize}
 
-(However, since the operating system allocates the stack for \main and for a
-thread's \entryfn, of course there is no implicit top-level stack frame. In
-a conforming implementation, returning from a thread's \entryfn may
-terminate all fibers on that thread. Returning from \main may terminate the
-whole process.)\\
-
 The above are all equivalent: stack variables are properly destroyed, since
 the stack is unwound. (See \nameref{destruction}.)\\
 
 In an environment that forbids exceptions, every \fiber you launch must
 terminate gracefully, by returning from its top-level function. You may not
 call \unwindfib. You may not call \dtor, explicitly or implicitly, on a
-valid \fiber instance.\\
+non-empty \fiber instance.\\
 
-When an explicitly-launched fiber's \entryfn returns a valid \fiber
-instance, that fiber is terminated. Control switches to the fiber indicated by
-the returned \fiber instance. The \entryfn may return (switch to) any
-reachable valid \fiber instance -- it need not be the instance originally
+When an explicitly-launched fiber's \entryfn returns a non-empty \fiber
+instance, the running fiber is terminated. Control switches to the fiber
+indicated by the returned \fiber instance. The \entryfn may return (switch to)
+any reachable non-empty \fiber instance -- it need not be the instance originally
 passed in, or an instance returned from any of the \resume family of
 methods.\\
 
-Returning an invalid \fiber instance (\opbool returns \cpp{false}) invokes
+Returning an empty \fiber instance (\opbool returns \cpp{false}) invokes
 undefined behavior.\\
 
 \emph{Calling} \resume means: ``Please switch to the indicated fiber; I
@@ -129,30 +123,33 @@ The specific characteristics of a \foreignex:
     for this.
     \item Along the way, as with a normal C++ exception, every object in every
     stack frame is destroyed.
-    \item \cpp{catch (...)} clauses along the way are executed, but:
-    \begin{itemize}
-        \item \cpp{throw;} resumes stack unwinding, as usual
-        \item a \cpp{catch (...)} clause that does not execute a \cpp{throw;}
-        statement behaves as if it ends with a \cpp{throw;} statement
-        \item a \cpp{catch (...)} clause that attempts to throw a normal C++
-        exception engages Undefined Behavior
-    \end{itemize}
-    \item \cpp{catch (}\emph{anything else}\cpp{)} clauses along the way are ignored. This is
+%%  \item \catchall clauses along the way are executed, but:
+%%  \begin{itemize}
+%%      \item \cpp{throw;} resumes stack unwinding, as usual
+%%      \item a \catchall clause that does not execute a \cpp{throw;}
+%%      statement behaves as if it ends with a \cpp{throw;} statement
+%%      \item a \catchall clause that attempts to throw a normal C++
+%%      exception engages Undefined Behavior
+%%  \end{itemize}
+%%  \item \cpp{catch (}\emph{anything else}\cpp{)}
+    \item \cpp{catch} clauses along the way are ignored. This is
     what is meant by the shorthand "uncatchable."
 \end{itemize}
 
 Since unwinding a fiber's stack requires destroying objects declared in stack
-frames, and may involve executing \cpp{catch (...)} clauses, it is worth
-pointing out that destroying a non-empty \fiber on a thread other than the
-thread on which it was last resumed will run those object destructors
-and \cpp{catch (...)} clauses on the thread destroying the \fiber instance.\\
+frames,
+%% and may involve executing \catchall clauses,
+it is worth pointing out that destroying a non-empty \fiber on a thread other
+than the thread on which it was last resumed will run those object destructors
+%% and \catchall clauses
+on the thread destroying the \fiber instance.\\
 
-As a consequence, destroying a \fiber instance representing \main or
-the initial stack of a \thread from any other thread engages Undefined
-Behavior.\footnote{One unobvious case would be if a fiber running on non-\main
-thread \cpp{T} stores a \fiber representing \cpp{T}'s default fiber in a static
-variable, whether module-scope or function-scope. That variable will be
-destroyed at program termination, probably on a thread other than \cpp{T}.}\\
+As a consequence, destroying a \fiber instance representing an implicit fiber
+from any other thread engages Undefined Behavior.\footnote{One unobvious case
+would be if a fiber running on non-\main thread \cpp{T} stores a \fiber
+representing \cpp{T}'s default fiber in a static variable, whether
+module-scope or function-scope. That variable will be destroyed at program
+termination, probably on a thread other than \cpp{T}.}\\
 
 Otherwise:
 


### PR DESCRIPTION
That means that formatting glitches such as overlength lines probably remain.

In addition, this revision does not yet:

* break out each of the `resume*()` variants as a separate block, starting with
  `resume_from_any_thread_with()`, describing each of the others as "equivalent
  to" (a call to the above).
* trim down notes (e.g. for `empty()`) to ensure each point appears uniquely.