### PR TITLE
Break out separate descriptions for resume family of methods.

### DIFF
--- a/P0876R6.tex
+++ b/P0876R6.tex
@@ -60,7 +60,7 @@
 \small
 \begin{tabbing}
     Document number: \= P0876R6\\
-    Date:            \> 2019-06-12\\
+    Date:            \> 2019-06-13\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> SG1\\

--- a/P0876R6.tex
+++ b/P0876R6.tex
@@ -60,7 +60,7 @@
 \small
 \begin{tabbing}
     Document number: \= P0876R6\\
-    Date:            \> 2019-06-10\\
+    Date:            \> 2019-06-12\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> SG1\\

--- a/abstract.tex
+++ b/abstract.tex
@@ -2,19 +2,20 @@
 
 This paper addresses concerns, questions and suggestions from the past meetings.
 The proposed API supersedes the former proposals N3985\cite{N3985},
-P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3}, P0876R0\cite{P0876R0}
-and P0876R2\cite{P0876R2}.\\
+P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3}
+and P0876R5\cite{P0876R5}.
+
 Because of name clashes with \emph{coroutine} from coroutine TS,
 \emph{execution context} from executor proposals and \emph{continuation} used
 in the context of \cpp{future::then()}, the committee has indicated
 that \emph{fiber} is preferable. However, given the foundational, low-level
 nature of this proposal, we choose \emph{fiber\_context}, leaving the
-term \emph{fiber} for a higher-level facility built on top of this one.\\
+term \emph{fiber} for a higher-level facility built on top of this one.
 
 The minimal API enables stackful context switching \bfs{without} the need for a
 \bfs{scheduler}. The API is suitable to act as building-block for high-level
 constructs such as stackful coroutines as well as cooperative multitasking
-(aka user-land/green threads that incorporate a \bfs{scheduling facility}).\\
+(aka user-land/green threads that incorporate a \bfs{scheduling facility}).
 
 Informally within this proposal, the term \emph{fiber} is used to denote the
 lightweight thread of execution launched and represented by the first-class

--- a/accelerators.tex
+++ b/accelerators.tex
@@ -8,10 +8,12 @@ provide capabilities for efficient vector processing\footnote{warp on CUDA
 devices, wavefront on AMD GPUs, 512-bit SIMD on Intel Xeon Phi}. Usually the
 host-directed execution uses \bfs{computation offloading} that permits
 executing computationally intensive work on a separate device
-(accelerator)\cite{OpenAcc}.\\
+(accelerator)\cite{OpenAcc}.
+
 For instance CUDA devices use a \bfs{command buffer} to establish communication
 between host and device. The host puts commands (op-codes) into the command
-buffer and the device process them \bfs{asynchronously}\cite{CUDA}.\\
+buffer and the device processes them \bfs{asynchronously}\cite{CUDA}.
+
 It is obvious that a fiber switch does \bfs{not} interact with
 \bfs{host-directed device-offloading}. A fiber switch works like a function
 call (see \nameref{callingconvention}).

--- a/api.tex
+++ b/api.tex
@@ -211,67 +211,45 @@ resumes a fiber\\
 \begin{tabular}{ l l }
     \midrule
 
-    \cpp{fiber\_context resume() &&} & (1)\\
-
-    \midrule
-
     \cpp{template<typename Fn>}\\
-    \cpp{fiber\_context resume\_with(Fn&& fn) &&} & (2)\\
-
-    \midrule
-
-    \cpp{fiber\_context resume\_from\_any\_thread() &&} & (3)\\
-
-    \midrule
-
-    \cpp{template<typename Fn>}\\
-    \cpp{fiber\_context resume\_from\_any\_thread\_with(Fn&& fn) &&} & (4)\\
+    \cpp{fiber\_context resume\_from\_any\_thread\_with(Fn&& fn) &&}\\
 
     \midrule
 \end{tabular}
 
+\requires
+\begin{description}
+    \item[---] \cpp{*this} represents a non-empty fiber (\cpp{empty()} returns \cpp{false})
+    \item[---] if \canxtresume would return \cpp{false}, \currthread is
+              the same as \lastthread
+\end{description}
+
 \effects
 \begin{description}
-    \item[1),3)]
-        \begin{description}
-            \item[---] The calling fiber is suspended.
-            \item[---] A new \fiber instance representing the suspended caller
-                       is synthesized. For purposes of exposition, call
-                       it \cpp{caller}.
-            \item[---] The fiber represented by \cpp{*this} is resumed.
-            \item[---] If this is the first entry to the fiber represented
-                       by \cpp{*this}, \cpp{caller} is passed to its \entryfn.
-            \item[---] Otherwise, the fiber represented by \cpp{*this}
-                       previously suspended by calling one
-                       of \allresume. \cpp{caller} is returned from whichever
-                       of the \cpp{resume} functions was called.
-        \end{description}
-    \item[2),4)] These member function templates shall not participate in overload
-              resolution unless \cpp{Fn} is \emph{Lvalue-Invocable} [func.wrap.func]
-              for the argument type \cpp{std::fiber\_context&&} and the return
-              type \fiber.\\
-              \bfs{SG1:} Needs update to \cpp{Invocable} idiom.
-        \begin{description}
-            \item[---] The calling fiber is suspended.
-            \item[---] A new \fiber instance representing the suspended caller
-                       is synthesized. For purposes of exposition, call
-                       it \cpp{caller}.
-            \item[---] The fiber represented by \cpp{*this} is resumed.
-            \item[---] Function \cpp{fn} is called on the newly-resumed fiber.
-            \item[---] \cpp{caller} is passed to \cpp{fn}.
-            \item[---] If \cpp{fn} throws an exception, the exception
-                       propagates on the newly-resumed fiber.
-            \item[---] Otherwise \cpp{fn} eventually returns a \fiber
-                       instance, which may or may not be the same
-                       as \cpp{caller}. For purposes of exposition, call
-                       it \cpp{returned}.
-            \item[---] If this is the first entry to the fiber represented
-                       by \cpp{*this}, \cpp{returned} is passed to its \entryfn.
-            \item[---] Otherwise, the fiber represented by \cpp{*this}
-                       previously suspended by calling one
-                       of \allresume. \cpp{returned} is returned from whichever
-                       of the \cpp{resume} functions was called.
-        \end{description}
+    \item[---] This member function template shall not participate in overload
+               resolution unless \cpp{Fn} is \emph{Lvalue-Invocable} [func.wrap.func]
+               for the argument type \cpp{std::fiber\_context&&} and the return
+               type \fiber.\\
+               \bfs{SG1:} Needs update to \cpp{Invocable} idiom.
+    \item[---] The execution context of the calling fiber is saved.
+    \item[---] The calling fiber is suspended.
+    \item[---] A new \fiber instance representing the suspended caller is
+               synthesized. For purposes of exposition, call it \cpp{caller}.
+    \item[---] The fiber represented by \cpp{*this} is resumed.
+    \item[---] The execution context of the resumed fiber is restored.
+    \item[---] The invocable \cpp{fn} is called on the newly-resumed fiber.
+    \item[---] \cpp{caller} is passed to \cpp{fn}.
+    \item[---] If \cpp{fn} throws an exception, the exception propagates on
+               the newly-resumed fiber.
+    \item[---] Otherwise \cpp{fn} eventually returns a \fiber instance. For
+               purposes of exposition, call it \cpp{returned}.
+               \tsnote{\cpp{returned} may or may not be the same as \cpp{caller}.}
+    \item[---] If this is the first entry to the fiber represented
+               by \cpp{*this}, \cpp{returned} is passed to its \entryfn.
+    \item[---] Otherwise, the fiber represented by \cpp{*this} previously
+               suspended itself by calling one of \allresume. \cpp{returned}
+               is returned from whichever of the \cpp{resume} functions was
+               called.
 \end{description}
 
 \params
@@ -281,8 +259,9 @@ resumes a fiber\\
 
 \returns
 \begin{description}
-    \item[fiber\_context] the returned instance represents the fiber that has been
-                 suspended in order to resume the current fiber
+    \item[fiber\_context] on resumption, \xtresumewith returns a \fiber
+               representing the immediately preceding fiber: the fiber that
+               resumed this one, thereby suspending itself
 \end{description}
 
 \except
@@ -290,29 +269,19 @@ resumes a fiber\\
 %   \item[---] \allresume throws
 %             \unwindex when, while suspended, the \fiber instance representing
 %             the suspended fiber is destroyed
-    \item[---] \allresume can
+    \item[---] \xtresumewith can
               throw \emph{any} exception if, while suspended:
               \begin{itemize}
                   \item some other fiber calls \someresumewith to
-                        resume this suspended fiber
+                        resume this suspended fiber, and
                   \item the function \cpp{fn} passed to \someresumewith
                         -- or some function called
                         by \cpp{fn} -- throws an exception
               \end{itemize}
     \item[---] Any exception thrown by the function \cpp{fn} passed
-              to \someresumewith, or any function called
+              to \xtresumewith, or any function called
               by \cpp{fn}, is thrown in the fiber referenced by \cpp{*this}
-              rather than in the fiber of the caller of \someresumewith.
-\end{description}
-
-\requires
-\begin{description}
-    \item[---] \cpp{*this} represents a non-empty fiber (\cpp{empty()} returns \cpp{false})
-    \item[---] for \resumesome, \currthread is the same as
-              \lastthread
-    \item[---] for \allresume, if\\
-              \canxtresume would return \cpp{false}, \currthread is
-              the same as \lastthread
+              rather than in the fiber of the caller of \xtresumewith.
 \end{description}
 
 \postcond
@@ -320,22 +289,12 @@ resumes a fiber\\
     \item[---] \cpp{*this} is made empty (\cpp{empty()} returns \cpp{true})
 \end{description}
 
-\tsnote{The intent of the distinction between \resume and \xtresume, as
-between \resumewith and \xtresumewith, is both for validation and for code
-auditing. If an application only ever calls \resumesome, no fiber
-will ever be resumed on a thread other than the one on which it was initially
-resumed.}
-
 \tsnote{The intent of the names \xtresume and \xtresumewith is to clarify the
 direction in which cross-thread resumption occurs. \Currthread always
 directly resumes a suspended fiber: control is passed into the suspended
 fiber, and the currently-running fiber suspends. These method names mean that
 the fiber represented by \cpp{*this} will be resumed whether or not it was
 last resumed on \currthread.}
-
-\tsnote{\allresume preserve the execution
-context of the calling fiber. Those data are restored if the calling fiber is
-resumed.}
 
 \tsnote{A suspended \cpp{fiber\_context} can be destroyed. Its resources will be cleaned
 up at that time.}
@@ -353,12 +312,57 @@ newly-emptied instance -- the instance on which the method was was called
 -- with the new instance returned by that call. This helps to avoid subsequent
 inadvertent attempts to resume the old, empty instance.}
 
-\tsnote{An injected function \cpp{fn()} must have signature
-\cpp{std::fiber\_context fn(std::fiber\_context&&)}.
-It will be passed a synthesized \fiber instance representing
-the suspended caller of \someresumewith.
-The \fiber instance returned by \cpp{fn()} is, in turn, used as
-the return value for the suspended function: \allresume.}
+\begin{tabular}{ l l }
+    \midrule
+
+    \cpp{template<typename Fn>}\\
+    \cpp{fiber\_context resume\_with(Fn&& fn) &&}\\
+
+    \midrule
+\end{tabular}
+
+\tsnote{The intent of the distinction between \resume and \xtresume, as
+between \resumewith and \xtresumewith, is both for validation and for code
+auditing. If an application only ever calls \resumesome, no fiber in that
+application will ever be resumed on a thread other than the one on which it
+was previously resumed.}
+
+\requires
+\begin{description}
+    \item[---] \cpp{*this} represents a non-empty fiber (\cpp{empty()} returns \cpp{false})
+    \item[---] \currthread is the same as \lastthread
+\end{description}
+
+\effects
+\begin{description}
+    \item[---] \resumewith has the same semantics as \xtresumewith.
+    \item[---] In addition, \resumewith may validate that \currthread is the
+               same as \lastthread.
+\end{description}
+
+\begin{tabular}{ l l }
+    \midrule
+
+    \cpp{fiber\_context resume\_from\_any\_thread() &&}\\
+
+    \midrule
+\end{tabular}
+
+\effects
+Equivalent to:\\
+\cpp{resume\_from\_any\_thread\_with([](fiber\_context&& caller)\{ return caller; \})}
+
+\begin{tabular}{ l l }
+    \midrule
+
+    \cpp{fiber\_context resume() &&}\\
+
+    \midrule
+\end{tabular}
+
+\effects
+Equivalent to:\\
+\cpp{resume\_with([](fiber\_context&& caller)\{ return caller; \})}
 
 \mbrhdr{bool can\_resume\_from\_this\_thread() noexcept}
 

--- a/api.tex
+++ b/api.tex
@@ -36,7 +36,7 @@ particular fiber, and returning from them, is independent of function calls
 and returns on any other fiber.
 
 Context switching can be effected by designating some other fiber's stack as
-current, in a manner appropriate to the implementation of function stacks.
+current, in a manner appropriate to the existing implementation of function stacks.
 
 \rSec3[fiber-context.empty]{Empty vs. Non-Empty}
 
@@ -63,14 +63,18 @@ particular, it is Undefined Behavior to attempt to resume a thread's default
 fiber on some other thread. We use the phrase \emph{explicit fiber}
 or \emph{explicitly-launched fiber} to designate a fiber instantiated by user
 code; conversely, \emph{implicit fiber} designates the default fiber on any
-thread.
+thread. An implicit fiber's \emph{owning thread} is the thread of which that
+fiber is the default fiber.
 
 \rSec3[fiber-context.toplevel]{Implicit Top-Level Stack Frame}
 
 On every explicit fiber, the facility injects an implicit top-level stack
-frame above the \entryfn passed to the constructor. If the fiber is later
+frame above the \entryfn passed to \fiber's constructor. If the fiber is later
 unwound, this implicit top-level stack frame serves as delimiter: this point
 is where unwinding stops.
+
+The top-level function must also catch any C++ exception escaping from the
+fiber's \entryfn and call \cpp{std::terminate}.
 
 Unwinding requires a non-empty \fiber instance indicating the fiber to which
 control should subsequently be passed. Once the terminated fiber's stack has
@@ -79,7 +83,8 @@ been fully unwound, the implicit top-level function resumes the indicated fiber.
 Similarly, on every implicit fiber, the runtime must pass control through an
 implicit top-level function above \main and above the \entryfn for
 each \thread. The stack frame delimits stack unwinding for each of these
-stacks.
+stacks. \tsnote{The implementation may use an existing implicit top-level
+function for this purpose.}
 
 However, the top-level function for an implicit fiber must destroy
 the \fiber instance representing the fiber that triggered stack unwinding.
@@ -93,7 +98,7 @@ the \fiber instance representing the fiber that triggered stack unwinding.
 \cppf{fiber}
 
 \mbrhdr{(constructor)}
-constructs new \cpp{fiber\_context}\\
+constructs new \cpp{fiber\_context}
 
 \begin{tabular}{ l l }
     \midrule
@@ -132,10 +137,10 @@ constructs new \cpp{fiber\_context}\\
 
 \remarks
 \begin{description}
-    \item[---] The entry-function \cpp{fn} is \emph{not} immediately
-              entered. The stack and any other necessary resources are created
-              on construction, but \cpp{fn} is not entered
-              until \allresume is called.
+    \item[---] The entry-function \cpp{fn} is \emph{not} immediately entered.\\
+              The stack and any other necessary resources are created
+              on construction, but \cpp{fn} is entered
+              only when \allresume is called.
     \item[---] A newly constructed but not yet entered fiber may be resumed by
               any thread. For any explicit fiber, the thread that resumes it
               is constrained only by the last thread that previously resumed
@@ -158,7 +163,8 @@ constructs new \cpp{fiber\_context}\\
 \remarks
 \begin{description}
     \item[---] Destroying a suspended fiber causes its stack to be unwound --
-               equivalent to calling \cpp{resume\_with(unwind\_fiber)}.
+               equivalent to calling\\
+               \cpp{resume\_from\_any\_thread\_with(unwind\_fiber)}.
     \item[---] The destructors of the stack variables on the suspended fiber
                represented by \cpp{*this}
 %%, and relevant \catchall clauses,
@@ -169,7 +175,7 @@ constructs new \cpp{fiber\_context}\\
 \end{description}
 
 \subparagraph*{operator=}
-moves the \fiber object\\
+moves the \fiber object
 
 \begin{tabular}{ l l }
     \midrule
@@ -191,7 +197,7 @@ moves the \fiber object\\
 
 \params
 \begin{description}
-    \item[other]   another \fiber to assign to this object\\
+    \item[other]   another \fiber to assign to this object
 \end{description}
 
 \returns
@@ -206,7 +212,7 @@ moves the \fiber object\\
 
 
 \subparagraph*{resume()}
-resumes a fiber\\
+resumes a fiber
 
 \begin{tabular}{ l l }
     \midrule
@@ -220,8 +226,7 @@ resumes a fiber\\
 \requires
 \begin{description}
     \item[---] \cpp{*this} represents a non-empty fiber (\cpp{empty()} returns \cpp{false})
-    \item[---] if \canxtresume would return \cpp{false}, \currthread is
-              the same as \lastthread
+    \item[---] \canxtresume would return \cpp{true}
 \end{description}
 
 \effects
@@ -244,6 +249,7 @@ resumes a fiber\\
     \item[---] Otherwise \cpp{fn} eventually returns a \fiber instance. For
                purposes of exposition, call it \cpp{returned}.
                \tsnote{\cpp{returned} may or may not be the same as \cpp{caller}.}
+               \tsnote{\cpp{returned} may be empty.}
     \item[---] If this is the first entry to the fiber represented
                by \cpp{*this}, \cpp{returned} is passed to its \entryfn.
     \item[---] Otherwise, the fiber represented by \cpp{*this} previously
@@ -368,24 +374,22 @@ Equivalent to:\\
 
 \effects
 query whether \currthread can resume the suspended\\
-\fiber instance by calling \xtresumesome. The implementation must
-return \cpp{false} if the suspended \fiber instance represents an implicit
-fiber, and \currthread is not that thread.\\
+\fiber instance by calling \xtresumesome.
 
 \returns
 \begin{description}
     \item[---] \cpp{fiber\_context::can\_resume\_from\_this\_thread()} returns \cpp{false}
         if \cpp{*this} is empty, or
         if it represents an implicit fiber,
-        and \currthread is not that thread; otherwise \cpp{true}.
+        and \currthread is not that fiber's owning thread; otherwise \cpp{true}.
 \end{description}
 
 \remarks
 \begin{description}
-    \item[---] When an implicit fiber is suspended, a \fiber instance represents that
-        suspended fiber. You may resume that suspended fiber \emph{on the same thread}
-        using any of \allresume. Attempting to
-        resume that suspended fiber from any other thread is Undefined Behavior.
+    \item[---] You may resume a suspended implicit fiber \emph{on the same thread}
+        using any of\\
+        \allresume. Attempting to
+        resume an implicit fiber from any thread other than its owning thread is Undefined Behavior.
     \item[---] \canxtresume returns \cpp{true} if \currthread is the same as \lastthread,
         or if the \fiber instance represents an explicit fiber.
     \item[---] \canxtresume is not marked \cpp{const} because in at least one
@@ -399,22 +403,20 @@ fiber, and \currthread is not that thread.\\
 
 \returns
 \cpp{false} if \cpp{*this} is empty, or if \currthread is not the same
-as \lastthread. \tsnote{When \canresume returns \cpp{true}, the\\ \fiber
-instance may be resumed by \allresume.}\\
+as \lastthread. \tsnote{When \canresume returns \cpp{true}, the \fiber
+instance may be resumed by \allresume.}
 
 \remarks
 \begin{description}
-    \item[---] returns \cpp{false} if \cpp{*this} is empty,
-        or if \currthread is not the same as \lastthread. Otherwise returns \cpp{true}.
     \item[---] \canresume is not marked \cpp{const} because in at least one
         implementation, it requires an internal context switch. However, the
         stack operations are effectively read-only. Nonetheless, if it is
-        possible for more than one thread to call \canxtresume concurrently on
+        possible for more than one thread to call \canresume concurrently on
         the same non-empty \fiber instance, locking is the caller's responsibility.
 \end{description}
 
 \subparagraph*{empty()}
-test whether \fiber is empty\\
+test whether \fiber is empty
 
 \begin{tabular}{ l l }
     \midrule
@@ -432,15 +434,11 @@ test whether \fiber is empty\\
 \begin{description}
     \item[1)] returns \cpp{false} if \cpp{*this} represents a fiber of
               execution, \cpp{true} otherwise.
-    \item[2)] equivalent to \cpp{(! empty())}
+    \item[2)] equivalent to \cpp{(\! empty())}
 \end{description}
 
-\tsnote{The essential points:
-\begin{itemize}
-    \item Regardless of the number of \fiber declarations, exactly one\\
-          \fiber instance represents each suspended fiber.
-    \item No \fiber instance represents the currently-running fiber.
-\end{itemize}}
+\tsnote{Regardless of the number of \fiber declarations, exactly one\\
+\fiber instance represents each suspended fiber.}
 
 \mbrhdr{void swap(fiber\_context& other) noexcept}
 
@@ -459,14 +457,14 @@ terminate the current running fiber.
 \remarks
 \begin{description}
     \item[---] On an explicit fiber, once the running fiber has
-               been fully unwound, \unwindfib resumes the fiber represented
-               by \cpp{other}. \tsnote{This is like returning \cpp{other} from
+               been fully unwound, its implicit top-level function resumes the fiber represented
+               by \cpp{other}. \tsnote{This is equivalent to returning \cpp{other} from
                the \entryfn, but may be called from any function on that
                fiber.}
     \item[---] On an implicit fiber, once the running fiber has been fully
-               unwound, \unwindfib destroys the fiber represented
+               unwound, its implicit top-level function destroys the fiber represented
                by \cpp{other}.
-    \item[---] The underlying Unwinding facility (for instance unwind facility
+    \item[---] The underlying Unwinding facility (for instance the unwind facility
                described in \emph{System V ABI for AMD64}) unwinds the stack
                to the implicit top-level stack frame and terminates the
                current fiber as described above.

--- a/code/return_from_resume_invalid.cpp
+++ b/code/return_from_resume_invalid.cpp
@@ -1,5 +1,5 @@
 int main(){
-    fiber_context f1,f2,f3;
+    fiber_context f1,f2,f3, holder;
     f3=fiber_context{[&](fiber_context&& f)->fiber_context{
         f2=std::move(f);
         for(;;){
@@ -16,7 +16,10 @@ int main(){
         }
         return {};
     }};
-    f1=fiber_context{[&](fiber_context&& /*main*/)->fiber_context{
+    f1=fiber_context{[&](fiber_context&& main)->fiber_context{
+        // important not to destroy the fiber_context instance representing
+        // main()
+        holder = std::move(main);
         for(;;){
             std::cout << "f1 ";
             f3=std::move(f2).resume();

--- a/code/synopsis.cpp
+++ b/code/synopsis.cpp
@@ -1,6 +1,6 @@
 #include <fiber_context>
 
-#define __cpp_lib_experimental_fiber_context 201902
+#define __cpp_lib_experimental_fiber_context 201907
 
 namespace std {
 namespace experimental {

--- a/code/unwind.cpp
+++ b/code/unwind.cpp
@@ -12,7 +12,7 @@ constexpr _Unwind_Exception_Class __gxx_fiber_exception_class
 
 class foreign_unwind_ex : public _Unwind_Exception {
 private:
-    static void fiber_unwind_cleanup( _Unwind_Reason_Code code, _Unwind_Exception * exc) {
+    static void fiber_unwind_cleanup(_Unwind_Reason_Code code, _Unwind_Exception *exc) {
         // We only want to be called through _Unwind_DeleteException.
         if ( _URC_FOREIGN_EXCEPTION_CAUGHT != code) {
             std::terminate();

--- a/control_transfer.tex
+++ b/control_transfer.tex
@@ -6,12 +6,13 @@ operations.
 
 \uabschnitt{symmetric fiber} A symmetric fiber provides a single
 control-transfer operation. This single operation requires that the control is
-passed explicitly between the fibers.\\
+passed explicitly between the fibers.
 \graphc{symm}
 
 \cppfl{symmetric_op}
 
-In the pseudo-code example above, a chain of fibers is created.\\
+In the pseudo-code example above, a chain of fibers is created.
+
 Control is transferred to fiber \cpp{f1} at line 15 and the lambda
 passed to constructor of \cpp{f1} is entered. Control is transferred from
 fiber \cpp{f1} to \cpp{f2} at line 12 and from \cpp{f2} to \cpp{f3} (line 9) and
@@ -21,7 +22,7 @@ fiber \cpp{f1} at line 3.
 \uabschnitt{asymmetric fiber} Two control-transfer operations are part of
 asymmetric fiber's interface: one operation for resuming (\resume) and one for
 suspending (\cpp{suspend()}) the fiber. The suspending operation returns
-control back to the calling fiber.\\
+control back to the calling fiber.
 \graphc{asymm}
 
 \cppfl{asymmetric_op}
@@ -30,26 +31,27 @@ line 16. Fiber \cpp{f1} resumes fiber \cpp{f2} at line 13 and so on. At line 2
 fiber \cpp{f4} calls its suspend operation \cpp{self::suspend()}. Fiber \cpp{f4}
 is suspended and \cpp{f3} resumed. Inside the lambda, \cpp{f3} returns from
 \cpp{f4.resume()} and calls \cpp{self::suspend()} (line 6). Fiber \cpp{f3} gets
-suspended while \cpp{f2} will be resumed and so on ...\\
+suspended while \cpp{f2} will be resumed and so on ...
+
 The asymmetric version needs \bfs{N-1 more} fiber switches than the variant
-using symmetric fibers.\\
+using symmetric fibers.
 
 \zs{While asymmetric fibers establish a caller-callee relationship (strongly
-coupled), symmetric fibers operate as siblings (loosely coupled).}\\
-\newline
+coupled), symmetric fibers operate as siblings (loosely coupled).}
 
 Symmetric fibers represent independent units of execution, making symmetric
 fibers a suitable mechanism for concurrent programming. Additionally,
 constructs that produce sequences of values (\emph{generators}) are easily
 constructed out of two symmetric fibers (one represents the caller, the other
-the callee).\\
+the callee).
 
 Asymmetric fibers incorporate additional fiber switches as shown in the pseudo
 code above. It is obvious that for a broad range of use cases, asymmetric
-fibers are less efficient than their symmetric counterparts.\\
+fibers are less efficient than their symmetric counterparts.
+
 Additionally, the calling fiber must be kept alive until the called fiber
 terminates. Otherwise the call of \cpp{suspend()} will be undefined behaviour
-(where to transfer execution control to?).\\
+(where to transfer execution control to?).
 
 \zs{Symmetric fibers are more efficient, have fewer restrictions (no
 caller-callee relationship) and can be used to create a wider set of

--- a/first_class.tex
+++ b/first_class.tex
@@ -2,13 +2,13 @@
 
 Because the symmetric control-transfer operation requires explicitly passing
 control between fibers, fibers must be expressed as
-\emph{first-class objects}.\\
+\emph{first-class objects}.
 
 Fibers exposed as first-class objects can be passed to and returned from
 functions, assigned to variables or stored into containers. With fibers as
 first-class objects, a program can \bfs{explicitly control the flow of
 execution} by suspending and resuming fibers, enabling control to pass into a
-function at exactly the point where it previously suspended.\\
+function at exactly the point where it previously suspended.
 
 \zs{Symmetric control-transfer operations require fibers to be first-class
 objects. First-class objects can be returned from functions, assigned to

--- a/history.tex
+++ b/history.tex
@@ -1,6 +1,6 @@
 \abschnitt{Revision History}\label{history}
-This document supersedes P0876R5.\\
-\newline
+This document supersedes P0876R5.
+
 Changes since P0876R5:
 
 \begin{itemize}
@@ -45,11 +45,11 @@ Problems resolved by discarding \unwindex in favor of a non-C++ \foreignex:
 We have also addressed what happens when a \fiber instance representing \main,
 or the default fiber on a \thread, is destroyed.
 
-Not yet addressed:
-
-\begin{itemize}
-    \item During stack unwinding, is an object's destructor allowed to resume
-      some other fiber?
+%%Not yet addressed:
+%%
+%%\begin{itemize}
+%%    \item During stack unwinding, is an object's destructor allowed to resume
+%%      some other fiber?
 %%  \item During stack unwinding, is a \catchall block allowed to
 %%    resume some other fiber?
-\end{itemize}
+%%\end{itemize}

--- a/implementation.tex
+++ b/implementation.tex
@@ -2,11 +2,11 @@
 
 \zs{This proposal does \so{NOT} seek to standardize any particular implementation or
 impose any specific calling convention!}
-\xspace\\
 
 Modern \bfs{micro-processors} are \bfs{register machines}; the content of
-processor registers represent the execution context of the program at a given
-point in time.\\
+processor registers represents the execution context of the program at a given
+point in time.
+
 \bfs{Operating systems} maintain for each process all relevant data (execution
 context, other hardware registers etc.) in the process table. The operating system's
 \bfs{CPU scheduler} periodically suspends and resumes processes in order to
@@ -14,10 +14,12 @@ share CPU time between multiple processes. When a process is suspended, its
 execution context (processor registers, instruction pointer, stack pointer, ...)
 is stored in the associated process table entry. On resumption, the CPU
 scheduler loads the execution context into the CPU and the process continues
-execution.\\
+execution.
+
 The CPU scheduler does a \bfs{full context switch}. Besides preserving
 the execution context (complete CPU state), the cache must be invalidated and
-the memory map modified.\\
+the memory map modified.
+
 A kernel-level context switch is several orders of magnitude slower than a
 context switch at user-level\cite{Tanenbaum2009}.
 
@@ -25,12 +27,15 @@ context switch at user-level\cite{Tanenbaum2009}.
 preserve the complete CPU state, e.g. all CPU registers. This requires that the
 implementation identifies the concrete micro-processor type and supported processor
 features. For instance the x86-architecture has several flavours of extensions
-such as MMX, SSE1-4, AVX1-2, AVX-512.\\
+such as MMX, SSE1-4, AVX1-2, AVX-512.
+
 Depending on the detected processor features, implementations of certain
 functionality must be switched on or off. The CPU scheduler in the operating system
-uses such information for context switching between processes.\\
+uses such information for context switching between processes.
+
 A fiber implementation using this strategy requires such a detection mechanism
-too (equivalent to swapper/\cpp{system_32()} in the Linux kernel).\\
+too (equivalent to swapper/\cpp{system_32()} in the Linux kernel).
+
 Aside from the complexity of such detection mechanisms, preserving the complete
 CPU state for each fiber switch is expensive.
 
@@ -44,26 +49,25 @@ an operating-system context switch; it only needs to be as transparent as a call
 to any other function. The calling convention -- the part of the ABI that
 specifies how a function's arguments and return values are passed -- determines
 which subset of micro-processor registers must be preserved by the called
-subroutine.\\
+subroutine.
 
 The \bfs{calling convention}\cite{SYSVABI} of \bfs{SYSV ABI} for \bfs{x86\_64}
 architecture determines that general purpose registers R12, R13, R14, R15, RBX
 and RBP must be preserved by the sub-routine - the first arguments are passed
 to functions via RDI, RSI, RDX, RCX, R8 and R9 and return values are stored in
-RAX, RDX.\\
+RAX, RDX.
+
 So on that platform, the \resume implementation preserves the \bfs{general
 purpose registers} (R12-R15, RBX and RBP) specified by the calling convention.
 In addition, the \bfs{stack pointer} and \bfs{instruction pointer} are
 preserved and exchanged too -- thus, from the point of view of calling
-code, \resume behaves like an ordinary function call.\\
+code, \resume behaves like an ordinary function call.
+
 In other words, \resume acts on the level of a simple function invocation --
-with the same performance characteristics (in terms of CPU cycles).\\
+with the same performance characteristics (in terms of CPU cycles).
 
 This technique is used in \bcontext\cite{bcontext} which acts as building block
-for \fbfibers\xspace and \bbquantum. The \fbfibers\xspace framework itself is the basis
-of many critical applications at Facebook, such as \fbmcrouter\cite{fbmcrouter}
-and some other Facebook services/libraries like ServiceRouter (routing framework
-for \fbthrift\cite{fbthrift}), Node API (graph ORM API for graph databases) ...
+for (e.g.) \fbfibers\xspace and \bbquantum; see section \nameref{low_level}.
 
 \uabschnitt{in-place substitution at compile time} During code generation,
 a compiler-based implementation could inject the assembler code responsible
@@ -73,20 +77,22 @@ invoke \resume).
 
 \uabschnitt{CPU state at the stack} Because each fiber must preserve CPU
 registers at suspension and load those registers at resumption, some storage
-is required.\\
+is required.
+
 Instead of allocating extra memory for each fiber, an implementation can use
 the stack by simply advancing the stack pointer at suspension and pushing the
 CPU registers (CPU state) onto the stack owned by the suspending fiber. When
 the fiber is resumed, the values are popped from the stack and loaded into the
-appropriate registers.\\
+appropriate registers.
 
 This strategy works because only a running fiber creates new stack frames
 (moving the stack pointer). While a fiber is suspended, it is safe to keep the
-CPU state on its stack.\\
+CPU state on its stack.
 
 Using the stack as storage for the CPU state has the additional advantage that
 \fiber must only contain a pointer to the stack location: its memory footprint
-can be that of a pointer.\\
+can be that of a pointer.
+
 Section \nameref{synthesizing} describes how global variables are avoided
 by synthesizing a \fiber from the active fiber (execution context) and passing
 this synthesized \fiber (representing the now-suspended fiber) into the resumed
@@ -95,7 +101,7 @@ implement.\footnote{The implementation of \bcontext\cite{bcontext} utilizes this
 technique.}
 Inside \resume the code pushes the relevant CPU registers onto the stack, and
 from the resulting stack address creates a new \fiber. This instance is then
-passed (or returned) into the resumed fiber (see \nameref{synthesizing}).\\
+passed (or returned) into the resumed fiber (see \nameref{synthesizing}).
 
 \zs{Using the active fiber's stack as storage for the CPU state is efficient because no
 additional allocations or deallocations are required.}

--- a/invalidation.tex
+++ b/invalidation.tex
@@ -1,22 +1,26 @@
 \abschnitt{invalidation at resumption}\label{invalidation}
 
 The framework must prevent the resumption of an already running or terminated
-(computation has finished) fiber.\\
+(computation has finished) fiber.
+
 Resuming an already running fiber will cause overwriting and corrupting the stack
 frames (note, the stack is not copyable).  Resuming a terminated fiber will
 cause undefined behaviour because the stack might already be unwound (objects
 allocated on the stack were destroyed or the memory used as stack was already
-deallocated).\\
+deallocated).
+
 As a consequence each call of \resume will empty the \fiber instance, therefore
-no instance of \fiber represents the currently-running fiber.\\
-Whether or not a \fiber is empty can be tested with member function \opbool.\\
+no instance of \fiber represents the currently-running fiber.
+
+Whether or not a \fiber is empty can be tested with member function \opbool.
+
 To make this more explicit, functions \resume, \resumewith, \xtresume
 and\\
 \xtresumewith are rvalue-reference qualified.
 %If a fiber calls \cpp{f.resume()} then the  fiber is suspended and \cpp{f} is
 %invalidated. When the fiber is resumed later, it returns from \cpp{f.resume()}
 %and instance \cpp{f} references the calling fiber (the fiber that has resumed
-%the current fiber).\\
+%the current fiber).
 
 The essential points:
 \begin{itemize}
@@ -26,7 +30,7 @@ The essential points:
 \end{itemize}
 
 Section \nameref{solution_gpub} describes how an instance of\\
-\fiber is synthesized from the active fiber that suspends.\\
+\fiber is synthesized from the active fiber that suspends.
 
 \zs{
 A fiber API must:

--- a/low_level.tex
+++ b/low_level.tex
@@ -1,9 +1,9 @@
-\abschnitt{\fiber as building block for higher-level frameworks}
+\abschnitt{\fiber as building block for higher-level frameworks}\label{low_level}
 
 A low-level API enables a rich set of higher-level frameworks that provide
 specific syntaxes/semantics suitable for specific domains. As an example, the
-following four frameworks are based on the low-level fiber switching API of
-\bcontext\cite{bcontext} (implements the API of this proposal).
+following frameworks are based on the low-level fiber switching API of
+\bcontext\cite{bcontext} (which implements the API proposed here).
 
 \uabschnitt{\bcoroutine}\cite{bcoroutine2} implements \bfs{asymmetric coroutines}
 \cpp{coroutine<>::push_type} and\\
@@ -29,8 +29,8 @@ The code itself looks like synchronous invocations while internally it uses
 asynchronous scheduling.
 
 \uabschnitt{\bfiber}\cite{bfiber} implements \bfs{user-land threads} and combines
-fibers with schedulers (scheduler-algorithms are customization points). The API
-is modelled after the \thread-API and contains objects like
+fibers with schedulers (the scheduler algorithm is a customization point). The API
+is modelled after the \thread API and contains objects such as
 \cpp{future}, \cpp{mutex},\\
 \cpp{condition_variable} ...
 \cppf{bfiber_ex}
@@ -44,7 +44,7 @@ event dispatching libraries.
 \fbfibers\xspace is used in many critical applications at Facebook for instance
 in \fbmcrouter\cite{fbmcrouter} and some other Facebook services/libraries like
 ServiceRouter (routing framework for \fbthrift\cite{fbthrift}), Node API (graph
-ORM API for graph databases) ...\\
+ORM API for graph databases) ...
 
 \uabschnitt{Bloomber's \bbquantum}\cite{bbquantum} is a full-featured and
 powerful C++ framework that allows users to dispatch units of work (a.k.a.

--- a/passing_data.tex
+++ b/passing_data.tex
@@ -7,19 +7,21 @@ wrapper (like \cpp{std::bind}) or lambda capture.
 The \resume call at line 8 enters the lambda and passes 1 into the
 new fiber. The value is incremented by one, as shown at line 4. The expression
 \cpp{caller.resume()} at line 5 resumes the original context (represented
-within the lambda by \cpp{caller}).\\
+within the lambda by \cpp{caller}).
+
 The call to \cpp{lambda.resume()} at line 10 resumes the lambda, returning from
 the \cpp{caller.resume()} call at line 5. The \fiber instance \cpp{caller}
 emptied by the \resume call at line 5 is replaced with the new instance
-returned by that same \resume call.\\
+returned by that same \resume call.
+
 Finally the lambda returns (the updated) \cpp{caller} at line 6, terminating its
-context.\\
+context.
 
 Since the updated \cpp{caller} represents the fiber suspended by the call at
-line 10, control returns to \main.\\
+line 10, control returns to \main.
 
 However, since context \cpp{lambda} has now terminated, the updated \cpp{lambda}
-is empty. Its \opbool returns \cpp{false}.\\
+is empty. Its \opbool returns \cpp{false}.
 
 \zs{Using lambda capture is the preferred way to transfer data between two
 fibers; global pointers or a calling wrapper (such as \cpp{std::bind}) are

--- a/problem_gp_ub.tex
+++ b/problem_gp_ub.tex
@@ -3,17 +3,20 @@ undefined behaviour}\label{problem_gpub}
 
 According to \emph{C++ core guidelines}\cite{coreguidlines}, non-const global
 variables should be avoided: they hide dependencies and make the
-dependencies subject to unpredictable changes.\\
+dependencies subject to unpredictable changes.
+
 Global variables can be changed by assigning them indirectly using a pointer or
 by a function call. As a consequence, the compiler can't cache the value of a
 global variable in a register, degrading performance (unnecessary
-loads and stores to global memory especially in performance critical loops).\\
+loads and stores to global memory especially in performance critical loops).
+
 Accessing a register is one to three orders of magnitude faster than accessing
 memory (depending on whether the cache line is in cache and not invalidated by
-another core; and depending on whether the page is in the TLB).\\
+another core; and depending on whether the page is in the TLB).
+
 The order of initialisation (and thus destruction) of static global
 variables is not defined, introducing additional problems with static
-global variables.\\
+global variables.
 
 \zs{A library designed to be used as building block by other higher-level
 frameworks should avoid introducing global variables. If this API were
@@ -28,7 +31,7 @@ restricts the valid use cases.
 For instance the generator pattern is impossible because the only way
 for a fiber to transfer execution control back to \main is to terminate. But
 this means that no way exists to transfer data (sequence of values) back and
-forth between a fiber and \main.\\
+forth between a fiber and \main.
 
 \zs{Switching to \main only by returning is impractical because it limits the
 applicability of fibers and requires an internal global variable pointing to

--- a/references.tex
+++ b/references.tex
@@ -8,7 +8,7 @@
     \bibitem{WinX64}
         \href{https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64?view=vs-2019}{x64 Windows unwinding}
 
-    \bibitem{WinArm64}
+    \bibitem{WinARM64}
         \href{https://docs.microsoft.com/en-us/cpp/build/arm64-exception-handling?view=vs-2019}{ARM64 Windows unwinding}
 
     \bibitem{OpenAcc}
@@ -56,6 +56,10 @@
     \bibitem{P0876R3}
         \href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0876r3.pdf}
         {P0876R3: fibers without scheduler}
+
+    \bibitem{P0876R5}
+        \href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0876r5.pdf}
+        {P0876R5: fibers without scheduler}
 
     \bibitem{coreguidlines}
         \href{http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Ri-global}

--- a/representation.tex
+++ b/representation.tex
@@ -2,4 +2,4 @@
 
 \zs{Note, that \cpp{m} represents the suspended \main as a \fiber! This is a nice
 feature because \main and each thread's \entryfn are handled equivalently to
-explicitly-created fibers.}\\
+explicitly-created fibers.}

--- a/resume_with.tex
+++ b/resume_with.tex
@@ -8,23 +8,25 @@ function \cpp{fn()} to execute.
 \cppfl{suspender}
 The \resumewith call at line 11 injects function \cpp{fn()} into
 fiber \cpp{f} as if the \resume call at line 3 had directly
-called \cpp{fn()}.\\
+called \cpp{fn()}.
 
 Like an \entryfn passed to \fiber, \cpp{fn()} must accept
 \cpp{std::fiber\_context&&} and return\\
 \fiber. The \fiber instance returned by \cpp{fn()} will, in turn, be returned
-to \cpp{f}'s lambda by the \resume at line 3.\\
+to \cpp{f}'s lambda by the \resume at line 3.
 
 Suppose that code running on the program's main fiber calls \resume (line 12 below), thereby
 entering the first lambda shown below. This is the point at which \cpp{m} is
-synthesized and passed into the lambda at line 2.\\
+synthesized and passed into the lambda at line 2.
+
 Suppose further that after doing some work (line 4), the lambda calls
 \cpp{m.resume()}, thereby switching back to the main fiber. The lambda remains
-suspended in the call to \cpp{m.resume()} at line 5.\\
+suspended in the call to \cpp{m.resume()} at line 5.
+
 At line 18 the main fiber calls \cpp{f.resume\_with()} where the passed lambda
 accepts \cpp{fiber\_context &&}. That new lambda is called on the fiber of the suspended
 lambda. It is as if the \cpp{m.resume()} call at line 8 directly called the second
-lambda.\\
+lambda.
 
 The function passed to \resumewith has almost the same range of possibilities as
 any function called on the fiber represented by \cpp{f}. Its special invocation
@@ -44,15 +46,15 @@ matters when control leaves it in either of two ways:
 \cppfl{ontop}
 
 The \cpp{f.resume\_with(<lambda>)} call at line 18 passes control to the second
-lambda on the fiber of the first lambda.\\
+lambda on the fiber of the first lambda.
 
 As usual, \resumewith synthesizes a \fiber instance representing the calling
 fiber, passed into the lambda as \cpp{m}. This particular lambda returns \cpp{m}
 unchanged at line 21; thus that \cpp{m} instance is returned by the \resume call
-at line 8.\\
+at line 8.
 
 Finally, the first lambda returns at line 10 the \cpp{m} variable updated at
-line 8, switching back to the main fiber.\\
+line 8, switching back to the main fiber.
 
 One case worth pointing out is when you call \resumewith (or \xtresumewith) on
 a\\

--- a/solution_gp_ub.tex
+++ b/solution_gp_ub.tex
@@ -14,57 +14,65 @@ fiber is first started, or returned from \resume).
 In the pseudo-code above the fiber \cpp{f} is started by invoking its member
 function \resume at line 7. This operation suspends \cpp{foo}, empties
 instance \cpp{f} and synthesizes a new \fiber\xspace \cpp{m} that is passed as parameter
-to the lambda of \cpp{f} (line 2).\\
+to the lambda of \cpp{f} (line 2).
+
 Invoking \cpp{m.resume()} (line 3) suspends the lambda, empties \cpp{m} and
 synthesizes a \fiber that is returned by \cpp{f.resume()} at line 7. The
 synthesized \fiber is assigned to \cpp{f}. Instance \cpp{f} now represents the
 suspended fiber running the lambda (suspended at line 3). Control is
-transferred from line 3 (lambda) to line 7 (\cpp{foo()}).\\
+transferred from line 3 (lambda) to line 7 (\cpp{foo()}).
+
 Call \cpp{f.resume()} at line 8 empties \cpp{f} and suspends \cpp{foo()}
 again. A \fiber representing the suspended \cpp{foo()} is synthesized, returned
 from \cpp{m.resume()} and assigned to \cpp{m} at line 3. Control
 is transferred back to the lambda and instance \cpp{m} represents the suspended
-\cpp{foo()}.\\
+\cpp{foo()}.
+
 Function \cpp{foo()} is resumed at line 4 by executing \cpp{m.resume()} so that
-control returns at line 8 and so on ...\\
+control returns at line 8 and so on ...
 
 Class \cpp{symmetric_coroutine<>::yield_type} from N3985\cite{N3985} is
-\bfs{not} equivalent to the synthesized \fiber.\\
+\bfs{not} equivalent to the synthesized \fiber.
+
 \cpp{symmetric_coroutine<>::yield_type} does not represent the suspended context,
 instead it is a special representation of the same coroutine. Thus \main or
 the current thread's \entryfn can \bfs{not} be represented by \cpp{yield_type}
-(see next section \nameref{representation}).\\
+(see next section \nameref{representation}).
+
 Because \cpp{symmetric_coroutine<>::yield_type()} yields back to the starting
 point, i.e. invocation of\\
 \cpp{symmetric_coroutine<>::call_type::operator()()},
 both instances (\cpp{call_type} as well as \cpp{yield_type}) must be preserved.
 Additionally the caller must be kept alive until the called coroutine terminates
-or UB happens at resumption.\\
+or UB happens at resumption.
 
 \zs{This API is specified in terms of passing the suspended \fiber. A higher
 level layer can hide that by using private variables.}
 
 \uabschnitt{representing \emph{main()} and thread's \entryfn as fiber}\label{representation}
 As shown in the previous section a synthesized fiber is created and passed
-into the resumed fiber as an instance of \fiber.\\
+into the resumed fiber as an instance of \fiber.
+
 \cppf{synthesized_main}
 
 The mechanism presented in this proposal describes switching between stacks: each
 fiber has its own stack. The stacks of \main and explicitly-launched threads
-are not excluded; these can be used as targets too.\\
+are not excluded; these can be used as targets too.
+
 \bfs{Thus every program can be considered to consist of fibers -- some
 created by the OS (\main stack; each thread's initial stack) and some created
-explicitly by the code.}\\
+explicitly by the code.}
+
 This is a nice feature because it allows (the stacks of) \main and each
 thread's \entryfn to be represented as fibers. A \fiber
 representing \main or a thread's \entryfn can be handled like an
 explicitly created \fiber: it can passed to and returned from functions or
 stored in a container. When called on such an instance, \canxtresume indicates
-whether it is valid to call \xtresumesome on that instance.\\
+whether it is valid to call \xtresumesome on that instance.
 
 In the code snippet above the suspended \main is represented by instance
 \cpp{m} and could be stored in containers or managed just like \cpp{f}
-by a scheduling algorithm.\\
+by a scheduling algorithm.
 
 \zs{The proposed fiber API allows representing and handling \main and the
 current thread's \entryfn by an instance of \fiber in the same way as
@@ -80,7 +88,7 @@ In line 5 the fiber is started by invoking \resume on instance \cpp{f}. \main
 is suspended and an instance of type \cpp{fiber\_context} is synthesized and passed as
 parameter \cpp{m} to the lambda at line 2. The fiber terminates by returning
 \cpp{m}. Control is transferred to \main (returning from \cpp{f.resume()} at
-line 5) while fiber \cpp{f} is destroyed.\\
+line 5) while fiber \cpp{f} is destroyed.
 
 In a more advanced example another \fiber is used as return value instead of the
 passed in synthesized fiber.
@@ -96,7 +104,7 @@ the first time). The synthesized \fiber\xspace \cpp{f} passed into the lambda at
 represents the terminated fiber \cpp{f2} (e.g. the calling fiber). Thus instance
 \cpp{f} is empty as the assert statement verifies at line 5. Fiber \cpp{f1} uses
 the captured \fiber\xspace \cpp{m} as return value (line 6). Control is returned to
-\main, returning from \cpp{f2.resume()} at line 13.\\
+\main, returning from \cpp{f2.resume()} at line 13.
 
 \zs{The function passed to \fiber's constructor must have
 signature `\cpp{fiber\_context(fiber\_context&&)}`. Using \fiber as the return
@@ -106,17 +114,21 @@ value from such a function avoids global variables.}
 An instance of \fiber remains empty after return from \resume, \resumewith,
 \xtresume or\\
 \xtresumewith -- the synthesized fiber is returned, instead of
-implicitly updating the\\\fiber instance on which \resume was called.\\
+implicitly updating the\\\fiber instance on which \resume was called.
+
 If the \fiber object were implicitly updated, the fiber would 
 change its identity because each fiber is associated with a stack. Each stack
 contains a chain of function calls (call stack). If this association were
-implicitly modified, unexpected behaviour happens.\\
+implicitly modified, unexpected behaviour happens.
+
 The example below demonstrates the problem:
 \cppfl{return_from_resume_inplace}
 
-In this pseudo-code the \fiber object is implicitly updated.\\
+In this pseudo-code the \fiber object is implicitly updated.
+
 The example creates a circle of fibers: each fiber prints its name and resumes
-the next fiber (f1 -> f2 -> f3 -> f1 -> ...).\\
+the next fiber (f1 -> f2 -> f3 -> f1 -> ...).
+
 Fiber \cpp{f1} is started at line 26. The synthesized \fiber\xspace \cpp{main} passed 
 to the resumed fiber is not used (control flow cycles through the three
 fibers).\footnote{The operating-system stack provided for \main or the current
@@ -129,7 +141,7 @@ resumes fiber \cpp{f1} at line 7. Inside \cpp{f1} control returns from
 this time fiber \cpp{f3} instead of \cpp{f2} is resumed. This is caused by the
 fact the instance \cpp{f2} gets the synthesized \fiber of \cpp{f3} implicitly
 assigned. Remember that at line 7 fiber \cpp{f3} gets suspended while \cpp{f1}
-is resumed through \cpp{f1.resume()}.\\
+is resumed through \cpp{f1.resume()}.
 
 This problem can be solved by returning the synthesized \fiber from \resume,
 \resumewith, \xtresume or \xtresumewith.
@@ -137,7 +149,7 @@ This problem can be solved by returning the synthesized \fiber from \resume,
 
 In the example above the synthesized \fiber returned by \resume is
 move-assigned to the invoking \fiber instance (that has resumed the current
-fiber).\\
+fiber).
 
 \zs{The synthesized \fiber must be returned from \resume, \resumewith,
 \xtresume and \xtresumewith in order to prevent changing the identity of the
@@ -152,26 +164,26 @@ synthesized \fiber to the correct \fiber instance (the caller).
 Picture a higher-level framework in which every fiber can find its associated
 \cpp{filament} instance, as well as others. Every context switch must be mediated by
 passing \emph{the target} \cpp{filament} instance to \emph{the running fiber's}
-\cpp{resume\_next()}.\\
+\cpp{resume\_next()}.
 
 Running fiber A has an associated \cpp{filament} instance \cpp{filamentA},
-whose \fiber \cpp{f\_} is empty -- because fiber A is running.\\
+whose \fiber \cpp{f\_} is empty -- because fiber A is running.
 
 Desiring to switch to suspended fiber B (with associated
 \cpp{filament} \cpp{filamentB}), running fiber A calls\\
-\cpp{filamentA.resume\_next(filamentB)}.\\
+\cpp{filamentA.resume\_next(filamentB)}.
 
 \cpp{resume\_next()} calls \cpp{filamentB.f\_.resume\_with(<lambda>)}.
-This empties \cpp{filamentB.f\_} -- because fiber B is now running.\\
+This empties \cpp{filamentB.f\_} -- because fiber B is now running.
 
 The lambda binds \cpp{&filamentA} as \cpp{this}. Running on fiber B, it
 receives a \fiber instance representing the newly-suspended fiber A as its
-parameter \cpp{f}. It moves that \fiber instance to \cpp{filamentA.f\_}.\\
+parameter \cpp{f}. It moves that \fiber instance to \cpp{filamentA.f\_}.
 
 The lambda then returns a default-constructed (therefore empty) \fiber
 instance. That empty instance is returned by the previously-suspended
 \resumewith call in \cpp{filamentB.resume\_next()} -- which is fine because
-\cpp{resume\_next()} drops it on the floor anyway.\\
+\cpp{resume\_next()} drops it on the floor anyway.
 
 Thus, the running fiber's associated \cpp{filament::f\_} is always empty,
 whereas the \cpp{filament} associated with each suspended fiber is continually

--- a/stack.tex
+++ b/stack.tex
@@ -3,15 +3,16 @@
 On construction of a \fiber a stack is allocated. If the \entryfn returns,
 the stack will be destroyed. If the function has not yet returned and the
 destructor of the \fiber instance representing that context is called,
-the stack will be unwound and destroyed.\\
+the stack will be unwound and destroyed.
 
 Consider a running fiber \cpp{f2} that destroys the \fiber instance
-representing \cpp{f1}.\\
+representing \cpp{f1}.
 
 \cpp{f1}'s destructor, running on \cpp{f2}, implicitly calls member-function
 \resumewith, passing \unwindfib as
 argument. Fiber \cpp{f1} will be temporarily resumed and \unwindfib is
-invoked.\\
+invoked.
+
 Function \unwindfib caches an instance of \fiber that
 represents \cpp{f2}, then unwinds \cpp{f1}'s stack
 (walking the stack and destroying automatic variables in reverse order of
@@ -19,7 +20,7 @@ construction).
 The first frame on \cpp{f1}'s stack, the one created by \fiber's constructor,
 stops the unwinding. It terminates \cpp{f1} by returning
 \cpp{f2}. Control is returned to \cpp{f2} and \cpp{f1}'s
-stack gets deallocated.\\
+stack gets deallocated.
 
 The stack on which \main is executed, as well as the stack implicitly
 created by \thread's constructor, is allocated by the operating

--- a/stack_management.tex
+++ b/stack_management.tex
@@ -2,9 +2,10 @@
 
 Each fiber is associated with a stack and is responsible for managing the lifespan
 of its stack (allocation at construction, deallocation when fiber terminates). The
-RAII-pattern\footnote{resource acquisition is initialisation} should apply.\\
+RAII-pattern\footnote{resource acquisition is initialisation} should apply.
 
-Copying a \fiber must not be permitted!\\
+Copying a \fiber must not be permitted!
+
 If a \fiber were copyable, then its stack with all the objects allocated on it
 must be copied too. That presents two implementation choices.
 \begin{itemize}
@@ -31,5 +32,5 @@ A fiber API must:
           deallocated when \fiber goes out of scope
     \item prevent accidentally copying the stack
 \end{itemize}
-Class \fiber must be \emph{moveable-only}.\\
+Class \fiber must be \emph{moveable-only}.
 }

--- a/termination.tex
+++ b/termination.tex
@@ -1,12 +1,12 @@
 \abschnitt{termination}
 
 There are a few different ways to terminate a given fiber without
-terminating the whole process, or engaging undefined behavior.\\
+terminating the whole process, or engaging undefined behavior.
 
 When a \fiber instance is constructed with an \entryfn, its new stack is
 initialized with the frame of an implicit top-level function that marks the
 end of the stack. \unwindfib unwinds the stack back to
-that top-level function, which returns to the \fiber passed to \unwindfib.\\
+that top-level function, which resumes the \fiber passed to \unwindfib.
 
 Therefore, any of the following will gracefully terminate a fiber:
 
@@ -19,32 +19,33 @@ Therefore, any of the following will gracefully terminate a fiber:
           does. Since\\\unwindfib accepts a \fiber, and since \resumewith
           synthesizes a\\\fiber representing its caller and passes it to the
           subject function, this terminates the fiber referenced by the
-          original \fiber instance and switches back to the caller.
+          original \fiber instance and then resumes the caller.
     \item Engage \dtor: switch to some other fiber, which will
           receive a \fiber instance representing the current fiber. Make that
           other fiber destroy the received \fiber instance.
 \end{itemize}
 
 The above are all equivalent: stack variables are properly destroyed, since
-the stack is unwound. (See \nameref{destruction}.)\\
+the stack is unwound. (See \nameref{unwinding}.)
 
 In an environment that forbids exceptions, every \fiber you launch must
-terminate gracefully, by returning from its top-level function. You may not
+terminate gracefully by returning from its top-level function. You may not
 call \unwindfib. You may not call \dtor, explicitly or implicitly, on a
-non-empty \fiber instance.\\
+non-empty \fiber instance. With these restrictions, it is possible to use
+the \fiber facility without exception support.
 
 When an explicitly-launched fiber's \entryfn returns a non-empty \fiber
 instance, the running fiber is terminated. Control switches to the fiber
 indicated by the returned \fiber instance. The \entryfn may return (switch to)
 any reachable non-empty \fiber instance -- it need not be the instance originally
 passed in, or an instance returned from any of the \resume family of
-methods.\\
+methods.
 
 Returning an empty \fiber instance (\opbool returns \cpp{false}) invokes
-undefined behavior.\\
+undefined behavior.
 
 \emph{Calling} \resume means: ``Please switch to the indicated fiber; I
-am suspending; please resume me later.''\\
+am suspending; please resume me later.''
 
 \emph{Returning} a particular \fiber means: ``Please switch to the indicated
 fiber; and by the way, I am done.''
@@ -56,7 +57,7 @@ Stack unwinding caused by an exception, thread termination or fiber
 destruction exits functions on that stack without executing a \cpp{return} statement. Local variables
 that go out of scope may have destructors that must be called.
 The implementation must walk the stack and call the destructor for each object
-in every such stack frame.\\
+in every such stack frame.
 
 The C++ standard does not define how exception handling is implemented. Stack unwinding differs
 among different systems. The process of stack unwinding is described in the
@@ -76,12 +77,12 @@ Unwinding happens under following circumstances:
 \end{itemize}
 \uwforced takes a \foreignex (non-C++ exception; for instance Java or GO) and walks the stack frame by frame
 inspecting the \emph{unwind tables} for cleanup functions (for instance destructors of
-local variables) and catch blocks.\\
+local variables) and catch blocks.
 
-\uwforced calls a \emph{personality routine} (\cpp{__gxx_personality_v0()} forGCC)\footnote{The
+\uwforced calls a \emph{personality routine} (\cpp{__gxx_personality_v0()} forGCC).\footnote{The
 personality routine passed by a specific runtime serves as interface between system unwinding library
 and language specific exception handling (not only C++; GO and Java are also supported). It is always invoked via pointer (saved
-as a function pointer in \ehframe for each stack frame).}
+as a function pointer in \ehframe\xspace for each stack frame).}
 \uwforced takes a stop function that controls the termination of the unwinding
 (reaching end of stack for fibers).
 The stop function intercepts calls to the personality routine, letting the external
@@ -90,7 +91,8 @@ a consequence the C++ personality routine deals only with C++ exceptions;
 it does not need to know anything specific about unwinding done by an external
 agent such as fiber or pthreads cancellation.}
 When the destination frame (last frame on fiber
-stack) is reached, control jumps back to the caller without literally returning.\\
+stack) is reached, control jumps back to the caller without further popping
+the stack.
 
 The code snippet below is a proof of concept available at \href{https://github.com/boostorg/context/tree/p0876r6}{Boost.Context branch p0876r6}.
 \cppf{unwind}
@@ -104,19 +106,22 @@ to the calling fiber once the last stack frame has been unwound.
 As stated in the \emph{SYS V AMD64 ABI}\cite{SYSVAMD64} standard:
 "A runtime is not allowed to catch an exception if the \cpp{_UA_FORCE_UNWIND} flag was passed to the personality routine."
 and "... since it is not possible to determine if a given catch clause will re-throw or not without executing it ...", the
-\foreignex must not be catchable by C++ \cpp{try-catch} blocks.\\
-As a consequence, \curex can not return a \cpp{std::exception\_ptr} pointing to a \foreignex.\\
+\foreignex must not be catchable by C++ \cpp{try-catch} blocks.
+
+As a consequence, \curex can not return a \cpp{std::exception\_ptr} pointing
+to a \foreignex.
+
 In order to detect if stack unwinding is currently in progress \uncex returns \cpp{true} and\\
-\uncexs counts the \foreignex.\\
+\uncexs counts the \foreignex.
 
 The rationale for moving to an uncatchable exception is further explained in
-the \nameref{history}.\\
+the \nameref{history}.
 
 The specific characteristics of a \foreignex:
 
 \begin{itemize}
     \item Throwing the \foreignex can only be effected by the \fiber
-    facility. The proposed \unwindfib is the only way to cause that
+    facility. The proposed \unwindfib function is the only way to cause that
     explicitly.
     \item The ultimate "catch" -- the point at which stack unwinding stops --
     is likewise determined by the \fiber facility. There is no explicit syntax
@@ -132,8 +137,7 @@ The specific characteristics of a \foreignex:
 %%      exception engages Undefined Behavior
 %%  \end{itemize}
 %%  \item \cpp{catch (}\emph{anything else}\cpp{)}
-    \item \cpp{catch} clauses along the way are ignored. This is
-    what is meant by the shorthand "uncatchable."
+    \item \cpp{catch} clauses along the way are ignored.
 \end{itemize}
 
 Since unwinding a fiber's stack requires destroying objects declared in stack
@@ -142,14 +146,15 @@ frames,
 it is worth pointing out that destroying a non-empty \fiber on a thread other
 than the thread on which it was last resumed will run those object destructors
 %% and \catchall clauses
-on the thread destroying the \fiber instance.\\
+on the thread destroying the \fiber instance.
 
 As a consequence, destroying a \fiber instance representing an implicit fiber
+(see \nameref{fiber-context.implicit})
 from any other thread engages Undefined Behavior.\footnote{One unobvious case
 would be if a fiber running on non-\main thread \cpp{T} stores a \fiber
 representing \cpp{T}'s default fiber in a static variable, whether
 module-scope or function-scope. That variable will be destroyed at program
-termination, probably on a thread other than \cpp{T}.}\\
+termination, probably on a thread other than \cpp{T}.}
 
 Otherwise:
 
@@ -173,7 +178,7 @@ certain point and then simply abandon it, leaving it unreachable.\footnote{A
 higher-level library built on this facility can introduce a scheduler. A
 scheduler could permit abandoning the \main fiber while continuing to run
 other fibers on the same thread; once the last of those fibers terminates, the
-scheduler can finally return from the \main fiber. But \fiber explicitly
+scheduler can finally return from the \main fiber. But \fiber intentionally
 avoids introducing a scheduler.} Destroying the \fiber representing \main must
 end by returning to the runtime.
 
@@ -205,6 +210,6 @@ equivalent to exiting the thread.
 
 The reasoning is the same as for the \fiber representing \main.
 
-\zs{The system's exception handling, i.e. its unwinding framework, is used to cleanup the stack
+\zs{The system's exception handling, i.e. its unwinding framework, is used to clean up the stack
 of a fiber by using a foreign exception that is not catchable by C++ \cpp{try-catch} blocks.}
 

--- a/tls.tex
+++ b/tls.tex
@@ -1,6 +1,6 @@
 \abschnitt{multi-threading environment}
 
-Member function \canxtresume returns \cpp{false} if the stack used by the
+Member function \canxtresume returns \cpp{false} if the stack represented by the
 \fiber instance was created by the operating system (main application or thread
 stack), and the caller is running on a different thread. When the stack
 represented by the \fiber instance was created by \fiber's
@@ -9,13 +9,13 @@ implementation could mark the first stack frame by creating a special marker
 (for instance \emph{0xBADCAFFEE} etc.) at a specific offset in the first stack
 frame or use a special function name for the first function and walk the stack
 searching for these markers.} You must not attempt to resume an instance
-representing a stack provided by the operating system on some other thread!\\
+representing a stack provided by the operating system on some other thread!
 
 \canresume can be called to determine whether a given \fiber instance might
-safely be resumed on a particular thread by calling \resume or \resumewith.\\
+safely be resumed on a particular thread by calling \resume or \resumewith.
 
 \fiber is TLS-agnostic - best practices related to TLS apply to fibers too
-(see P0772R0.)\\
+(see P0772R0.)
 
 There could potentially be Undefined Behavior if:
 \begin{itemize}
@@ -28,7 +28,7 @@ There could potentially be Undefined Behavior if:
 
 The cached TLS pointer is now pointing to storage belonging to some other
 thread. If the original thread terminates before the new thread, the cached
-TLS pointer is now dangling.\\
+TLS pointer is now dangling.
 
 For a runtime that caches TLS pointers in such fashion, an implementation
 of \xtresume or\\


### PR DESCRIPTION
Minor editorial tweaks.
Among other things, normalize paragraph breaks.