### PR TITLE
Specify returning empty fiber_context for thread/process termination.

### DIFF
--- a/P0876R6.tex
+++ b/P0876R6.tex
@@ -60,7 +60,7 @@
 \small
 \begin{tabbing}
     Document number: \= P0876R6\\
-    Date:            \> 2019-06-13\\
+    Date:            \> 2019-06-14\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> SG1\\

--- a/P0876R6.tex
+++ b/P0876R6.tex
@@ -60,7 +60,7 @@
 \small
 \begin{tabbing}
     Document number: \= P0876R6\\
-    Date:            \> 2019-06-14\\
+    Date:            \> 2019-06-17\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> SG1\\

--- a/api.tex
+++ b/api.tex
@@ -48,9 +48,9 @@ representing a suspended fiber is non-empty.
 
 It is convenient to take the position that every kernel thread in a program,
 including the default thread on which the program runs \main, has an initial
-\emph{default fiber} whose stack is allocated by the host operating system. Thus,
+\emph{default fiber} whose stack is allocated by the host operating system. \tsnote{Thus,
 when \main instantiates a new \fiber, it becomes the second fiber on
-that thread.
+that thread.}
 
 Upon resumption of a fiber, a non-empty \fiber instance is passed in
 representing the newly-suspended previous fiber. This \fiber instance might
@@ -64,30 +64,45 @@ fiber on some other thread. We use the phrase \emph{explicit fiber}
 or \emph{explicitly-launched fiber} to designate a fiber instantiated by user
 code; conversely, \emph{implicit fiber} designates the default fiber on any
 thread. An implicit fiber's \emph{owning thread} is the thread of which that
-fiber is the default fiber.
+fiber is the default fiber. An explicit fiber has no owning thread. Instead,
+when necessary, we speak of the thread on which a fiber was last resumed.
 
-\rSec3[fiber-context.toplevel]{Implicit Top-Level Stack Frame}
+\rSec3[fiber-context.toplevel]{Implicit Top-Level Function}
 
 On every explicit fiber, the facility injects an implicit top-level stack
 frame above the \entryfn passed to \fiber's constructor. If the fiber is later
 unwound, this implicit top-level stack frame serves as delimiter: this point
 is where unwinding stops.
 
-The top-level function must also catch any C++ exception escaping from the
+The top-level function must catch any C++ exception escaping from the
 fiber's \entryfn and call \cpp{std::terminate}.
 
-Unwinding requires a non-empty \fiber instance indicating the fiber to which
-control should subsequently be passed. Once the terminated fiber's stack has
-been fully unwound, the implicit top-level function resumes the indicated fiber.
+Returning a \fiber instance from the explicit fiber's \entryfn returns control
+to the implicit top-level function. Similarly, when \unwindfib unwinds a fiber
+stack, it returns to the implicit top-level function the \fiber instance it
+was passed. Either way, the implicit top-level function is responsible for
+deallocating the explicit fiber's stack memory.
 
 Similarly, on every implicit fiber, the runtime must pass control through an
 implicit top-level function above \main and above the \entryfn for
-each \thread. The stack frame delimits stack unwinding for each of these
-stacks. \tsnote{The implementation may use an existing implicit top-level
-function for this purpose.}
+each \thread. The stack frame for this implicit top-level function delimits
+stack unwinding for each of these stacks. If the fiber stack is unwound,
+control is returned to this implicit top-level function. The top-level
+function for an implicit fiber does not deallocate the fiber's stack memory,
+since the OS will do that.
 
-However, the top-level function for an implicit fiber must destroy
-the \fiber instance representing the fiber that triggered stack unwinding.
+\begin{itemize}
+    \item If a non-empty \fiber instance is returned to the implicit top-level
+    function (for either an explicit or implicit fiber), the fiber represented
+    by that \fiber instance is resumed.
+    \item If an empty \fiber instance is returned to the implicit top-level
+    function for an explicit fiber, the calling thread is terminated.
+    \item If an empty \fiber instance is returned to the implicit top-level
+    function for the default fiber of an explicit thread, that thread is
+    terminated.
+    \item If an empty \fiber instance is returned to the implicit top-level
+    function above \main, the process is terminated.
+\end{itemize}
 
 \rSec3[fiber-context.synopis]{Header <experimental/fiber\_context> synopsis}
 
@@ -456,20 +471,18 @@ terminate the current running fiber.
 
 \remarks
 \begin{description}
-    \item[---] On an explicit fiber, once the running fiber has
-               been fully unwound, its implicit top-level function resumes the fiber represented
-               by \cpp{other}. \tsnote{This is equivalent to returning \cpp{other} from
-               the \entryfn, but may be called from any function on that
-               fiber.}
-    \item[---] On an implicit fiber, once the running fiber has been fully
-               unwound, its implicit top-level function destroys the fiber represented
-               by \cpp{other}.
     \item[---] The underlying Unwinding facility (for instance the unwind facility
                described in \emph{System V ABI for AMD64}) unwinds the stack
                to the implicit top-level stack frame and terminates the
                current fiber as described above.
     \item[---] Unwinding the fiber's stack causes its stack variables to be
                destroyed.
+    \item[---] During this specific stack unwinding, 
+%% only \catchall clauses are executed. No other
+               no \cpp{catch} clauses are executed, not even \catchall.
+    \item[---] Once the running fiber has been fully unwound, \cpp{other} is
+               returned to the fiber's implicit top-level function as
+               described in \nameref{fiber-context.toplevel}.
 %%  \item[---] Unwinding the fiber's stack causes relevant \catchall
 %%             clauses to be executed.
 %%  \item[---] During this specific stack unwinding, a \catchall
@@ -478,19 +491,11 @@ terminate the current running fiber.
 %%  \item[---] During this specific stack unwinding, a \catchall
 %%             clause that attempts to throw any C++ exception engages
 %%             Undefined Behavior.
-    \item[---] During this specific stack unwinding, 
-%% only \catchall clauses are executed. No other
-               no \cpp{catch} clauses are executed, not even \catchall.
 \end{description}
 
 \params
 \begin{description}
     \item[other] the \fiber to which to switch once the current fiber has terminated
-\end{description}
-
-\requires
-\begin{description}
-    \item[---] \cpp{other} must not be empty (\cpp{empty()} returns \cpp{false})
 \end{description}
 
 \returns

--- a/code/return_from_resume_inplace.cpp
+++ b/code/return_from_resume_inplace.cpp
@@ -1,5 +1,5 @@
 int main(){
-    fiber_context f1,f2,f3, holder;
+    fiber_context f1,f2,f3;
     f3=fiber_context{[&](fiber_context&& f)->fiber_context{
         f2=std::move(f);
         for(;;){
@@ -16,10 +16,7 @@ int main(){
         }
         return {};
     }};
-    f1=fiber_context{[&](fiber_context&& main)->fiber_context{
-        // important not to destroy the fiber_context instance representing
-        // main()
-        holder = std::move(main);
+    f1=fiber_context{[&](fiber_context&& /*main*/)->fiber_context{
         for(;;){
             std::cout << "f1 ";
             std::move(f2).resume();

--- a/code/return_from_resume_invalid.cpp
+++ b/code/return_from_resume_invalid.cpp
@@ -1,5 +1,5 @@
 int main(){
-    fiber_context f1,f2,f3, holder;
+    fiber_context f1,f2,f3;
     f3=fiber_context{[&](fiber_context&& f)->fiber_context{
         f2=std::move(f);
         for(;;){
@@ -16,10 +16,7 @@ int main(){
         }
         return {};
     }};
-    f1=fiber_context{[&](fiber_context&& main)->fiber_context{
-        // important not to destroy the fiber_context instance representing
-        // main()
-        holder = std::move(main);
+    f1=fiber_context{[&](fiber_context&& /*main*/)->fiber_context{
         for(;;){
             std::cout << "f1 ";
             f3=std::move(f2).resume();

--- a/low_level.tex
+++ b/low_level.tex
@@ -58,11 +58,11 @@ parallel \cpp{forEach} and \cpp{mapReduce} functions.
 
 \uabschnitt{Habanero Extreme Scale Software Research Project\cite{habanero}}
 provides a task-based parallel programming model via its \hclib\cite{hclib}.
-The runtime provides work-stealing, async-finish\footnote{async-finish is a
-variation of fork-join model. While a task might fork a group of
-child tasks the child tasks might fork even more tasks. All tasks can
-potentially run in parallel with each other. The model allows a parent task
-selectively joining on a sub-set of child tasks.},
+The runtime provides work-stealing, async-finish,\footnote{async-finish is a
+variant of the fork-join model. While a task might fork a group of
+child tasks, the child tasks might fork even more tasks. All tasks can
+potentially run in parallel with each other. The model allows a parent task to
+selectively join a subset of child tasks.}
 parallel-for and future-promise parallel programming patterns. The library is not an exascale
 programming system itself, but it manages intra-node resources and schedules
 components within an exascale programming system.

--- a/termination.tex
+++ b/termination.tex
@@ -41,15 +41,17 @@ any reachable non-empty \fiber instance -- it need not be the instance originall
 passed in, or an instance returned from any of the \resume family of
 methods.
 
-Returning an empty \fiber instance (\opbool returns \cpp{false}) invokes
-undefined behavior.
-
 \emph{Calling} \resume means: ``Please switch to the indicated fiber; I
 am suspending; please resume me later.''
 
 \emph{Returning} a particular \fiber means: ``Please switch to the indicated
 fiber; and by the way, I am done.''
 
+The \emph{last} fiber on a particular thread has no non-empty \fiber to
+return. For this reason, returning an empty \fiber instance (\opbool
+returns \cpp{false}) terminates the calling thread. This is true whether or
+not the thread's default fiber (see \nameref{fiber-context.implicit}) has
+terminated.
 
 \uabschnitt{stack unwinding}\label{unwinding}
 
@@ -140,6 +142,9 @@ The specific characteristics of a \foreignex:
     \item \cpp{catch} clauses along the way are ignored.
 \end{itemize}
 
+\zs{The system's exception handling, i.e. its unwinding framework, is used to clean up the stack
+of a fiber by using a foreign exception that is not catchable by C++ \cpp{try-catch} blocks.}
+
 Since unwinding a fiber's stack requires destroying objects declared in stack
 frames,
 %% and may involve executing \catchall clauses,
@@ -148,68 +153,46 @@ than the thread on which it was last resumed will run those object destructors
 %% and \catchall clauses
 on the thread destroying the \fiber instance.
 
-As a consequence, destroying a \fiber instance representing an implicit fiber
-(see \nameref{fiber-context.implicit})
+As a consequence, destroying a \fiber instance representing a thread's default
+fiber (see \nameref{fiber-context.implicit})
 from any other thread engages Undefined Behavior.\footnote{One unobvious case
 would be if a fiber running on non-\main thread \cpp{T} stores a \fiber
 representing \cpp{T}'s default fiber in a static variable, whether
 module-scope or function-scope. That variable will be destroyed at program
 termination, probably on a thread other than \cpp{T}.}
 
-Otherwise:
+\subparagraph{marker frame}
 
-\subparagraph{destroying a \fiber representing \main}\label{destroymain} is equivalent to terminating the application.
+The \fiber facility must inject an implicit top-level function above
+each explicit fiber's \entryfn. (See \nameref{fiber-context.implicit}) This
+top-level function serves to delimit stack unwinding. Once the stack has been
+unwound to that point, control returns to the implicit top-level function. The
+implicit top-level function is responsible for freeing the explicit fiber's
+stack memory and for resuming the \fiber designated as the next fiber.
 
-The C++ runtime must inject a stack frame above \main that serves to stop
-stack unwinding due to the \foreignex. This is similar to, but different than,
-the stack frame above the \entryfn for an explicitly launched fiber.
+\subparagraph{destroying a \fiber representing a thread's default fiber}
 
-\unwindfib must always be called with a non-empty \fiber instance. That \fiber
-value is cached while the terminated fiber's stack is unwound.
+Similarly, the C++ runtime must inject a stack marker at or above \main (and
+each explicitly-launched thread's \entryfn) that serves to delimit stack
+unwinding due to the \foreignex. Unlike an explicit fiber's top-level
+function, though, the top-level function on a thread's default fiber
+does \emph{not} deallocate that fiber's stack: the OS, which provided the
+stack in the first place, will do that.
 
-As its last act, the top-level stack frame on an explicitly launched fiber
-resumes the cached \fiber.
+Unwinding the stack belonging to a thread's default fiber leaves the stack
+allocated but unreachable. That thread may continue to execute explict fibers
+as long as desired.
 
-In contrast, the stack frame injected above \main must finally \emph{destroy}
-the cached \fiber.
+Ultimately, however, it must be possible to exit a fiber in such as way as to
+terminate the calling thread. Returning an empty \fiber instance from
+a fiber's \entryfn terminates the running thread. Consequently, passing an
+empty \fiber instance to \unwindfib also terminates the calling thread.
 
-It is not reasonable to unwind (e.g.) the stack belonging to \main to a
-certain point and then simply abandon it, leaving it unreachable.\footnote{A
-higher-level library built on this facility can introduce a scheduler. A
-scheduler could permit abandoning the \main fiber while continuing to run
-other fibers on the same thread; once the last of those fibers terminates, the
-scheduler can finally return from the \main fiber. But \fiber intentionally
-avoids introducing a scheduler.} Destroying the \fiber representing \main must
-end by returning to the runtime.
+The \fiber facility does not defend against the case in which a thread's
+default fiber suspends (rather than terminating), but the explicit fiber it
+resumes ultimately causes thread termination in either of the ways described
+above. A higher-level library built on \fiber can provide a scheduler.
+The \fiber facility intentionally does not.
 
-Consider fiber F0: the default thread's default fiber, the fiber on
-which \main is called. F0 launches fiber F1, storing F1's \fiber in a
-stack variable, then launches F2. F2 destroys the \fiber instance representing
-F0.
-
-F0's stack is unwound with F2's \fiber instance cached.
-
-At some point along the way, the stack frame containing F1's \fiber is
-destroyed, thus F1's \fiber is destroyed. F0's stack unwinding is temporarily
-suspended and F1's stack is unwound. During this nested unwinding, F0's \fiber
-is cached.
-
-Once F1's stack is unwound -- because F1 was explicitly launched -- its
-implicit top-level function resumes F0's \fiber. This frees F1's stack memory
-and resumes unwinding F0's stack.
-
-Once F0's stack is unwound, as noted above, its top-level function must return
-to the runtime to terminate the process. However, F2 is still suspended at the
-point of destroying F0's (original) \fiber instance! F2's stack still exists!
-
-Therefore, F0's top-level function must destroy F2's cached \fiber instance
-before returning to the runtime.
-
-\subparagraph{destroying a \fiber representing \cpp{std::thread}} is
-equivalent to exiting the thread.
-
-The reasoning is the same as for the \fiber representing \main.
-
-\zs{The system's exception handling, i.e. its unwinding framework, is used to clean up the stack
-of a fiber by using a foreign exception that is not catchable by C++ \cpp{try-catch} blocks.}
-
+The top-level function above \main, given an empty \fiber instance to resume,
+terminates the whole process instead of that one thread.


### PR DESCRIPTION
Remove requirement for implicit fiber's top-level function to destroy returned
fiber_context. Explicitly allow terminating an implicit fiber while continuing
to run explicit fibers on the same thread.