### PR TITLE
 R7 changes: remove unwind_fiber() and all implicit unwinding.

### DIFF
--- a/D0876R7.tex
+++ b/D0876R7.tex
@@ -60,7 +60,7 @@
 \small
 \begin{tabbing}
     Document number: \= D0876R7\\
-    Date:            \> 2019-06-17\\
+    Date:            \> 2019-07-15\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> SG1\\

--- a/D0876R7.tex
+++ b/D0876R7.tex
@@ -59,7 +59,7 @@
 \begin{document}
 \small
 \begin{tabbing}
-    Document number: \= P0876R6\\
+    Document number: \= D0876R7\\
     Date:            \> 2019-06-17\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\

--- a/abstract.tex
+++ b/abstract.tex
@@ -3,7 +3,7 @@
 This paper addresses concerns, questions and suggestions from the past meetings.
 The proposed API supersedes the former proposals N3985\cite{N3985},
 P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3}
-and P0876R5\cite{P0876R5}.
+and P0876R6\cite{P0876R6}.
 
 Because of name clashes with \emph{coroutine} from coroutine TS,
 \emph{execution context} from executor proposals and \emph{continuation} used

--- a/api.tex
+++ b/api.tex
@@ -70,25 +70,30 @@ when necessary, we speak of the thread on which a fiber was last resumed.
 \rSec3[fiber-context.toplevel]{Implicit Top-Level Function}
 
 On every explicit fiber, the behavior is equivalent to injecting an implicit top-level stack
-frame above the \entryfn passed to \fiber's constructor. If the fiber is later
-unwound, this conceptual top-level stack frame serves as delimiter: this point
-is where unwinding stops.
+frame above the \entryfn passed to \fiber's constructor.
+%% If the fiber is later
+%% unwound, this conceptual top-level stack frame serves as delimiter: this point
+%% is where unwinding stops.
 
 The conceptual top-level function must catch any C++ exception escaping from the
 fiber's \entryfn and call \cpp{std::terminate}.
 
 Returning a \fiber instance from the explicit fiber's \entryfn is equivalent
-to returning control to the implicit top-level function. Similarly,
-when \unwindfib unwinds a fiber stack, it conceptually returns the \fiber
-instance it was passed to the implicit top-level function. Either way, the
+to returning control to the implicit top-level function.
+%% Similarly,
+%% when \unwindfib unwinds a fiber stack, it conceptually returns the \fiber
+%% instance it was passed to the implicit top-level function. Either way, the
+The
 conceptual implicit top-level function is responsible for deallocating the
 explicit fiber's stack memory.
 
 Similarly, on every implicit fiber, the behavior is equivalent to passing control through an
 implicit top-level function above \main and above the \entryfn for
-each \thread. The conceptual stack frame for this implicit top-level function delimits
-stack unwinding for each of these stacks. If the fiber stack is unwound,
-control is conceptually returned to this implicit top-level function. The conceptual top-level
+each \thread.
+%% The conceptual stack frame for this implicit top-level function delimits
+%% stack unwinding for each of these stacks. If the fiber stack is unwound,
+%% control is conceptually returned to this implicit top-level function.
+The conceptual top-level
 function for an implicit fiber does not deallocate the fiber's stack memory,
 since the OS will do that.
 
@@ -123,8 +128,8 @@ constructs new \cpp{fiber\_context}
 
     \midrule
 
-    \cpp{template<typename Fn>}\\
-    \cpp{explicit fiber\_context(Fn&& fn)} & (2)\\
+    \cpp{template<typename Fn0, typename Fn1>}\\
+    \cpp{explicit fiber\_context(Fn0&& entry, Fn1&& cancel)} & (2)\\
 
     \midrule
 
@@ -140,20 +145,20 @@ constructs new \cpp{fiber\_context}
 \begin{description}
     \item[1)] this constructor instantiates an empty \fiber. Its \cpp{empty()} method
               returns \cpp{true}.
-    \item[2)] takes a invocable object [func.def] as
-              argument. The invocable must have signature \cpp{fiber\_context
+    \item[2)] takes invocable objects [func.def] as
+              arguments. The invocables must have signature \cpp{fiber\_context
               fn(fiber\_context&&)}. This constructor template shall not
-              participate in overload resolution unless \cpp{Fn}
-              is \emph{Lvalue-Invocable} [func.wrap.func] for the argument
+              participate in overload resolution unless \cpp{Fn0} and \cpp{Fn1}
+              are \emph{Lvalue-Invocable} [func.wrap.func] for the argument
               type \cpp{std::fiber\_context&&} and the return type \fiber.\\
-              \bfs{SG1:} Needs update to \cpp{Invocable} idiom.
+              \bfs{SG1:} Needs update to \cpp{Invocable} concept.
     \item[3)] moves underlying state to new \fiber
     \item[4)] copy constructor deleted
 \end{description}
 
 \remarks
 \begin{description}
-    \item[---] The entry-function \cpp{fn} is \emph{not} immediately entered.\\
+    \item[---] The entry-function \cpp{entry} is \emph{not} immediately entered.
               The stack and any other necessary resources are created
               on construction, but \cpp{fn} is entered
               only when \allresume is called.
@@ -162,9 +167,11 @@ constructs new \cpp{fiber\_context}
               is constrained only by the last thread that previously resumed
               it -- and that constraint is imposed by operations performed by
               the fiber, rather than by the \fiber facility itself.
-    \item[---] The entry-function \cpp{fn} passed to \fiber
+    \item[---] The entry-function \cpp{entry} passed to \fiber
               will be passed a synthesized \fiber instance representing the
               suspended caller of \allresume.
+    \item[---] The \cancelfn \cpp{cancel} is invoked only when a non-empty
+              \fiber instance is destroyed. See \cpp{\~fiber\_context()}.
 \end{description}
 
 \mbrhdr{\~fiber\_context()}
@@ -178,17 +185,24 @@ constructs new \cpp{fiber\_context}
 
 \remarks
 \begin{description}
-    \item[---] Destroying a suspended fiber causes its stack to be unwound --
-               equivalent to calling\\
-               \cpp{resume\_from\_any\_thread\_with(unwind\_fiber)}.
-    \item[---] The destructors of the stack variables on the suspended fiber
-               represented by \cpp{*this}
-%%, and relevant \catchall clauses,
-               are run on the thread calling \dtor.
-    \item[---] As a consequence, destroying a \fiber instance
-               representing an implicit fiber from some other
-               thread engages Undefined Behavior.
+    \item[---] If \cpp{empty()} returns \cpp{false} at the time a \fiber
+               instance is destroyed, the destructor performs a call
+               equivalent to \cpp{resume\_from\_any\_thread\_with(cancellation-function)}.
+%%    \item[---] Destroying a suspended fiber causes its stack to be unwound --
+%%               equivalent to calling\\
+%%               \cpp{resume\_from\_any\_thread\_with(unwind\_fiber)}.
+%%    \item[---] The destructors of the stack variables on the suspended fiber
+%%               represented by \cpp{*this}
+%%%%, and relevant \catchall clauses,
+%%               are run on the thread calling \dtor.
+%%    \item[---] As a consequence, destroying a \fiber instance
+%%               representing an implicit fiber from some other
+%%               thread engages Undefined Behavior.
 \end{description}
+
+\tsnote{The \cancelfn must communicate to the fiber represented by \cpp{*this}
+the requirement to terminate. It may throw an exception or set some state
+visible to the fiber logic.}
 
 \subparagraph*{operator=}
 moves the \fiber object
@@ -251,7 +265,7 @@ resumes a fiber
                resolution unless \cpp{Fn} is \emph{Lvalue-Invocable} [func.wrap.func]
                for the argument type \cpp{std::fiber\_context&&} and the return
                type \fiber.\\
-               \bfs{SG1:} Needs update to \cpp{Invocable} idiom.
+               \bfs{SG1:} Needs update to \cpp{Invocable} concept.
     \item[---] The execution context of the calling fiber is saved.
     \item[---] The calling fiber is suspended.
     \item[---] A new \fiber instance representing the suspended caller is
@@ -318,8 +332,7 @@ fiber, and the currently-running fiber suspends. These method names mean that
 the fiber represented by \cpp{*this} will be resumed whether or not it was
 last resumed on \currthread.}
 
-\tsnote{A suspended \cpp{fiber\_context} can be destroyed. Its resources will be cleaned
-up at that time.}
+\tsnote{A suspended \cpp{fiber\_context} can be destroyed.}
 
 \tsnote{The returned \cpp{fiber\_context} indicates via \cpp{empty()} whether the previous active
 fiber has terminated (returned from \entryfn).}
@@ -463,48 +476,48 @@ test whether \fiber is empty
     \item[---] Exchanges the state of \cpp{*this} with \cpp{other}.
 \end{description}
 
-\rSec3[fiber-context.unwinding]{Function unwind\_fiber()}
-
-\mbrhdr{[[ noreturn ]] void unwind\_fiber(fiber\_context&& other)}
-
-\effects
-terminate the current running fiber.
-
-\remarks
-\begin{description}
-    \item[---] The underlying Unwinding facility (for instance the unwind facility
-               described in \emph{System V ABI for AMD64}) unwinds the stack
-               to the implicit top-level stack frame and terminates the
-               current fiber as described above.
-    \item[---] Unwinding the fiber's stack causes its stack variables to be
-               destroyed.
-    \item[---] During this specific stack unwinding, 
-%% only \catchall clauses are executed. No other
-               no \cpp{catch} clauses are executed, not even \catchall.
-    \item[---] Once the running fiber has been fully unwound, \cpp{other} is
-               returned to the fiber's conceptual top-level function as
-               described in \nameref{fiber-context.toplevel}.
-%%  \item[---] Unwinding the fiber's stack causes relevant \catchall
-%%             clauses to be executed.
-%%  \item[---] During this specific stack unwinding, a \catchall
-%%             clause that does not execute a \cpp{throw;} statement behaves
-%%             as if it ended with a \cpp{throw;} statement.
-%%  \item[---] During this specific stack unwinding, a \catchall
-%%             clause that attempts to throw any C++ exception engages
-%%             Undefined Behavior.
-\end{description}
-
-\params
-\begin{description}
-    \item[other] the \fiber to which to switch once the current fiber has terminated
-\end{description}
-
-\returns
-\begin{description}
-    \item[---] None: \unwindfib does not return
-\end{description}
-
-\except
-\begin{description}
-    \item[---] None catchable by C++
-\end{description}
+%% \rSec3[fiber-context.unwinding]{Function unwind\_fiber()}
+%% 
+%% \mbrhdr{[[ noreturn ]] void unwind\_fiber(fiber\_context&& other)}
+%% 
+%% \effects
+%% terminate the current running fiber.
+%% 
+%% \remarks
+%% \begin{description}
+%%     \item[---] The underlying Unwinding facility (for instance the unwind facility
+%%                described in \emph{System V ABI for AMD64}) unwinds the stack
+%%                to the implicit top-level stack frame and terminates the
+%%                current fiber as described above.
+%%     \item[---] Unwinding the fiber's stack causes its stack variables to be
+%%                destroyed.
+%%     \item[---] During this specific stack unwinding, 
+%% %% only \catchall clauses are executed. No other
+%%                no \cpp{catch} clauses are executed, not even \catchall.
+%%     \item[---] Once the running fiber has been fully unwound, \cpp{other} is
+%%                returned to the fiber's conceptual top-level function as
+%%                described in \nameref{fiber-context.toplevel}.
+%% %%  \item[---] Unwinding the fiber's stack causes relevant \catchall
+%% %%             clauses to be executed.
+%% %%  \item[---] During this specific stack unwinding, a \catchall
+%% %%             clause that does not execute a \cpp{throw;} statement behaves
+%% %%             as if it ended with a \cpp{throw;} statement.
+%% %%  \item[---] During this specific stack unwinding, a \catchall
+%% %%             clause that attempts to throw any C++ exception engages
+%% %%             Undefined Behavior.
+%% \end{description}
+%% 
+%% \params
+%% \begin{description}
+%%     \item[other] the \fiber to which to switch once the current fiber has terminated
+%% \end{description}
+%% 
+%% \returns
+%% \begin{description}
+%%     \item[---] None: \unwindfib does not return
+%% \end{description}
+%% 
+%% \except
+%% \begin{description}
+%%     \item[---] None catchable by C++
+%% \end{description}

--- a/code/fiber.cpp
+++ b/code/fiber.cpp
@@ -6,8 +6,8 @@ class fiber_context {
 public:
     fiber_context() noexcept;
 
-    template<typename Fn>
-    explicit fiber_context(Fn&& fn);
+    template<typename Fn0, typename Fn1>
+    explicit fiber_context(Fn0&& entry, Fn1&& cancel);
 
     ~fiber_context();
 

--- a/code/synopsis.cpp
+++ b/code/synopsis.cpp
@@ -8,10 +8,6 @@ inline namespace concurrency_v2 {
 
 class fiber_context;
 
-class unwind_exception;
-
-void unwind_fiber(fiber_context&& other);
-
 } // namespace concurrency_v2
 } // namespace experimental
 } // namespace std

--- a/commands.tex
+++ b/commands.tex
@@ -100,6 +100,7 @@
 \newcommand{\sym}{\emph{symmetric}\xspace}
 \newcommand{\asym}{\emph{asymmetric}\xspace}
 \newcommand{\entryfn}{\emph{entry-function}\xspace}
+\newcommand{\cancelfn}{\emph{cancellation-function}\xspace}
 \newcommand{\dbframe}{\emph{.debug\_frame}}
 \newcommand{\ehframe}{\emph{.eh\_frame}}
 \newcommand{\foreignex}{\emph{foreign exception}\xspace}

--- a/exceptions.tex
+++ b/exceptions.tex
@@ -1,7 +1,9 @@
 \abschnitt{exceptions}\label{exceptions}
 
-In general, if an uncaught exception escapes from a fiber's \entryfn,
-\cpp{std::terminate} is called. There is one exception: the \foreignex used to
-unwind fiber stacks. The \fiber facility internally uses this \foreignex to
-clean up the stack of a suspended fiber being destroyed. Because this
-exception is a \foreignex, it can not be caught.
+%% In general, 
+If an uncaught exception escapes from a fiber's \entryfn,
+\cpp{std::terminate} is called.
+%% There is one exception: the \foreignex used to
+%% unwind fiber stacks. The \fiber facility internally uses this \foreignex to
+%% clean up the stack of a suspended fiber being destroyed. Because this
+%% exception is a \foreignex, it can not be caught.

--- a/history.tex
+++ b/history.tex
@@ -1,7 +1,7 @@
 \abschnitt{Revision History}\label{history}
-This document supersedes P0876R5.
+This document supersedes P0876R6.
 
-Changes since P0876R5:
+Changes since P0876R6:
 
 \begin{itemize}
     \item \cpp{std::unwind\_exception} removed: stack unwinding must be

--- a/history.tex
+++ b/history.tex
@@ -4,8 +4,40 @@ This document supersedes P0876R6.
 Changes since P0876R6:
 
 \begin{itemize}
-    \item \cpp{std::unwind\_exception} removed: stack unwinding must be
-      performed by platform facilities.
+    \item Implicit stack unwinding (by non-C++ exception) removed.
+    \item \unwindfib removed.
+    \item Cancellation function added to \fiber constructor.
+\end{itemize}
+
+In Cologne 2019, SG1 took the position that:
+
+\begin{itemize}
+    \item The \cpp{fiber\_context} facility is not the only C++ feature that
+          requires ``special'' unwinding (special function exit path).
+    \item Such functionality should be decoupled from \fiber. It requires its
+          own proposal that follows its own course through WG21 process.
+    \item Depending on this (yet to be written) proposal would unduly delay
+          the \cpp{fiber\_context} facility.
+    \item For now, the \cpp{fiber\_context} facility should adopt a ``less is
+          more'' approach, removing promises about implicit unwinding, placing
+          the burden on the consumer of the facility instead.
+    \item This leaves the way open for \cpp{fiber\_context} to integrate with
+          a new, improved unwind facility when such becomes available.
+\end{itemize}
+
+The idea of making \fiber's constructor accept a cancellation function was
+suggested to permit consumer opt-in to P0876R5 functionality where
+permissible, or convey to the fiber in question by any suitable means the need
+to clean up and terminate.
+
+Requiring the cancellation function is partly because it remains unclear what
+the default should be, and partly to allow specifying later that the default
+engages the new, imporved unwind facility.
+
+Changes since P0876R5:
+
+\begin{itemize}
+    \item \cpp{std::unwind\_exception} removed.
     \item \cpp{fiber\_context::can\_resume\_from\_any\_thread()} renamed to
       \canxtresume.
     \item \cpp{fiber\_context::valid()} renamed to \cpp{empty()} with inverted
@@ -14,42 +46,26 @@ Changes since P0876R6:
       logic governing each fiber.
 \end{itemize}
 
-The change to unwinding fiber stacks using an anonymous \foreignex not
-catchable by C++ \cpp{try} / \cpp{catch} blocks is in response to deep
+\unwindex was removed in response to deep
 discussions in Kona 2019 of the surprisingly numerous problems surfaced by
 using an ordinary C++ exception for that purpose.
 
-Further information about the specific mechanism can be found in
-\nameref{unwinding} et ff.
-
-Problems resolved by discarding \unwindex in favor of a non-C++ \foreignex:
+Problems resolved by discarding \unwindex:
 \begin{itemize}
     \item When unwinding a fiber stack, it is essential to know the subsequent
           fiber to resume. \unwindex therefore bound a \fiber. \fiber is
           move-only. But C++ exceptions must be copyable.
     \item It was possible to catch and discard \unwindex, with problematic
-          consequences for its bound \fiber. The new mechanism does not permit
-          that.
-    \item Similarly, it used to be possible to catch \unwindex but not rethrow it.
+          consequences for its bound \fiber.
+    \item Similarly, it was possible to catch \unwindex but not rethrow it.
     \item If we attempted to address the problem above by introducing a
           \unwindex operation to extract the bound \fiber, it became possible
           to rethrow the exception with an empty (moved-from) \fiber instance.
     \item Throwing a C++ exception during C++ exception unwinding terminates
-          the program. But destroying a \fiber no longer causes a C++
-          exception to be thrown.
+          the program. It was possible for an exception implementation based
+          on \cpp{thread\_local} to become confused by exceptions on different
+          fibers on the same thread.
     \item It is no longer possible to capture \unwindex with
           \cpp{std::exception\_ptr} and migrate it to a different fiber -- or
           a different thread.
 \end{itemize}
-
-We have also addressed what happens when a \fiber instance representing \main,
-or the default fiber on a \thread, is destroyed.
-
-%%Not yet addressed:
-%%
-%%\begin{itemize}
-%%    \item During stack unwinding, is an object's destructor allowed to resume
-%%      some other fiber?
-%%  \item During stack unwinding, is a \catchall block allowed to
-%%    resume some other fiber?
-%%\end{itemize}

--- a/references.tex
+++ b/references.tex
@@ -61,6 +61,10 @@
         \href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0876r5.pdf}
         {P0876R5: fibers without scheduler}
 
+    \bibitem{P0876R6}
+        \href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0876r6.pdf}
+        {P0876R6: fibers without scheduler}
+
     \bibitem{coreguidlines}
         \href{http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Ri-global}
         {C++ Core Guidelines}

--- a/rev
+++ b/rev
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Usage:
+# rev R7
+# or
+# rev D0876R7
+# Finds the most recent previous [PD]0876R*.tex and updates version references
+# accordingly.
+
+PNUM="0876"
+
+cd "$(dirname "$0")"
+
+# Convert user's specified revision (in any of several forms) to P0876Rx
+pfx="${1:0:1}"
+case "$pfx" in
+    P|D)
+        # user specified the entire P0876Rx
+        newrev="$1"
+        ;;
+    R)
+        # user specified just the Rx
+        newrev="P$PNUM$1"
+        ;;
+    *)
+        if [ $(($1+0)) == "$1" ]
+        then # $1 is an int
+            newrev="P${PNUM}R$1"
+        else
+            echo "Unrecognized revision '$1'" >&2
+            exit 1
+        fi
+        ;;
+esac
+
+# There should be only one master .tex file, but in case we turn up more than
+# one, reverse-sort names, skipping the first character, and take the first.
+oldtex="$(ls [PD]${PNUM}R*.tex | sort -k1.2r | head -n 1)"
+oldrev="${oldtex%.tex}"
+
+# Find the URL for the published oldrev
+oldurl="$(curl --silent --location --head --output /dev/null --write-out '%{url_effective}' -- https://wg21.link/$oldrev)"
+
+# Find the rev previous to oldrev
+prevrev="$(sed -n -E "s/^.*supersedes ([PD]0876R.*)\..*/\1/p" history.tex)"
+
+echo "Updating $oldrev -> $newrev"
+echo "$oldrev URL: $oldurl"
+echo "Previous to $oldrev was $prevrev"
+
+git mv "$oldtex" "$newrev.tex"
+sed -i.tex~ "s/$oldrev/$newrev/" "$newrev.tex"
+sed -i.tex~ "s/$prevrev\\\\cite{$prevrev}/$oldrev\\\\cite{$oldrev}/" abstract.tex
+sed -i.tex~ -E "s/(supersedes |since )$prevrev/\\1$oldrev/" history.tex
+
+# This sed command needs a bit of explanation.
+# We want to inject a new \bibitem{$oldrev} block just like (and just after)
+# the \bibitem{$prevrev} block. Each such block is 4 lines long, including the
+# trailing blank line. So search for \bibitem{$prevrev}, then suck the next 3
+# lines into the pattern space. Immediately print the pattern space BEFORE
+# changing it -- that is, we want to append to the \bibitem{$prevrev} block
+# rather than replacing it. Then substitute $prevrev with $oldrev. Then
+# substitute the old url in \href{...} with \href{$oldurl}. But inside
+# \href{...} we must use [^[:space:]]* rather than simply .* because .*, being
+# greedy, spans lines and will eat through the close } and the subsequent open
+# { and all the way up to the second }. Don't explicitly print the pattern
+# space again because that's implied (since we didn't specify the -n switch).
+sed -i.tex~ -f <(echo \
+"/\bibitem{$prevrev}/{ N
+N
+N
+p
+s/$prevrev/$oldrev/g
+s!\href{[^[:space:]]*}!\href{$oldurl}!
+}") references.tex
+
+git diff

--- a/solution_gp_ub.tex
+++ b/solution_gp_ub.tex
@@ -106,7 +106,7 @@ represents the terminated fiber \cpp{f2} (e.g. the calling fiber). Thus instance
 the captured \fiber\xspace \cpp{m} as return value (line 6). Control is returned to
 \main, returning from \cpp{f2.resume()} at line 13.
 
-\zs{The function passed to \fiber's constructor must have
+\zs{The \entryfn passed to \fiber's constructor must have
 signature `\cpp{fiber\_context(fiber\_context&&)}`. Using \fiber as the return
 value from such a function avoids global variables.}
 

--- a/stack.tex
+++ b/stack.tex
@@ -3,26 +3,36 @@
 On construction of a \fiber a stack is allocated. If the \entryfn returns,
 the stack will be destroyed. If the function has not yet returned and the
 destructor of the \fiber instance representing that context is called,
-the stack will be unwound and destroyed.
+%% the stack will be unwound and destroyed.
+the calling program is responsible for unwinding the stack.
+
+The fiber's \cancelfn is used to trigger cleanup.
 
 Consider a running fiber \cpp{f2} that destroys the \fiber instance
 representing \cpp{f1}.
 
 \cpp{f1}'s destructor, running on \cpp{f2}, implicitly calls member-function
-\resumewith, passing \unwindfib as
-argument. Fiber \cpp{f1} will be temporarily resumed and \unwindfib is
+\resumewith, passing the fiber's \cancelfn as
+argument. Fiber \cpp{f1} will be temporarily resumed and the \cancelfn is
 invoked.
 
-Function \unwindfib caches an instance of \fiber that
-represents \cpp{f2}, then unwinds \cpp{f1}'s stack
-(walking the stack and destroying automatic variables in reverse order of
-construction).
-The first frame on \cpp{f1}'s stack, the one created by \fiber's constructor,
-stops the unwinding. It terminates \cpp{f1} by returning
-\cpp{f2}. Control is returned to \cpp{f2} and \cpp{f1}'s
-stack gets deallocated.
+The \cancelfn must communicate to fiber \cpp{f1} the need to terminate. It
+might throw an exception. It might set a distinguished value in some object
+tested by code on \cpp{f1}. In any case, fiber \cpp{f2} remains suspended
+in \cpp{f1}'s destructor until \cpp{f1}'s \entryfn returns (the \fiber
+instance synthesized for) \cpp{f2} -- or until \cpp{f2} is explicitly resumed
+in some other way.
 
-The stack on which \main is executed, as well as the stack implicitly
-created by \thread's constructor, is allocated by the operating
-system. Such stacks are recognized by \fiber, and are not deallocated by its
-destructor.
+%% Function \unwindfib caches an instance of \fiber that
+%% represents \cpp{f2}, then unwinds \cpp{f1}'s stack
+%% (walking the stack and destroying automatic variables in reverse order of
+%% construction).
+%% The first frame on \cpp{f1}'s stack, the one created by \fiber's constructor,
+%% stops the unwinding. It terminates \cpp{f1} by returning
+%% \cpp{f2}. Control is returned to \cpp{f2} and \cpp{f1}'s
+%% stack gets deallocated.
+
+%% The stack on which \main is executed, as well as the stack implicitly
+%% created by \thread's constructor, is allocated by the operating
+%% system. Such stacks are recognized by \fiber, and are not deallocated by its
+%% destructor.

--- a/termination.tex
+++ b/termination.tex
@@ -1,38 +1,40 @@
 \abschnitt{termination}
 
-There are a few different ways to terminate a given fiber without
-terminating the whole process, or engaging undefined behavior.
-
-When a \fiber instance is constructed with an \entryfn, its new stack is
-initialized with the frame of an implicit top-level function that marks the
-end of the stack. \unwindfib unwinds the stack back to
-that top-level function, which resumes the \fiber passed to \unwindfib.
-
-Therefore, any of the following will gracefully terminate a fiber:
-
-\begin{itemize}
-    \item Cause its \entryfn to return a non-empty \fiber.
-    \item From within the fiber you wish to terminate, call \unwindfib with a
-          non-empty \fiber. That fiber will be resumed
-          when the active fiber terminates.
-    \item Call \cpp{fiber\_context::resume\_with(unwind\_fiber)}. This is what \dtor
-          does. Since\\\unwindfib accepts a \fiber, and since \resumewith
-          synthesizes a\\\fiber representing its caller and passes it to the
-          subject function, this terminates the fiber referenced by the
-          original \fiber instance and then resumes the caller.
-    \item Engage \dtor: switch to some other fiber, which will
-          receive a \fiber instance representing the current fiber. Make that
-          other fiber destroy the received \fiber instance.
-\end{itemize}
-
-The above are all equivalent: stack variables are properly destroyed, since
-the stack is unwound. (See \nameref{unwinding}.)
-
-In an environment that forbids exceptions, every \fiber you launch must
-terminate gracefully by returning from its top-level function. You may not
-call \unwindfib. You may not call \dtor, explicitly or implicitly, on a
-non-empty \fiber instance. With these restrictions, it is possible to use
-the \fiber facility without exception support.
+%% There are a few different ways to terminate a given fiber without
+%% terminating the whole process, or engaging undefined behavior.
+%% 
+%% When a \fiber instance is constructed with an \entryfn, its new stack is
+%% initialized with the frame of an implicit top-level function that marks the
+%% end of the stack. \unwindfib unwinds the stack back to
+%% that top-level function, which resumes the \fiber passed to \unwindfib.
+%% 
+%% Therefore, any of the following will gracefully terminate a fiber:
+%% 
+%% \begin{itemize}
+%%     \item Cause its \entryfn to return a non-empty \fiber.
+%%     \item From within the fiber you wish to terminate, call \unwindfib with a
+%%           non-empty \fiber. That fiber will be resumed
+%%           when the active fiber terminates.
+%%     \item Call \cpp{fiber\_context::resume\_with(unwind\_fiber)}. This is what \dtor
+%%           does. Since\\\unwindfib accepts a \fiber, and since \resumewith
+%%           synthesizes a\\\fiber representing its caller and passes it to the
+%%           subject function, this terminates the fiber referenced by the
+%%           original \fiber instance and then resumes the caller.
+%%     \item Engage \dtor: switch to some other fiber, which will
+%%           receive a \fiber instance representing the current fiber. Make that
+%%           other fiber destroy the received \fiber instance.
+%% \end{itemize}
+%% 
+%% The above are all equivalent: stack variables are properly destroyed, since
+%% the stack is unwound. (See \nameref{unwinding}.)
+%% 
+%% In an environment that forbids exceptions, 
+Every \fiber you launch must
+terminate gracefully by returning from its top-level function.
+%% You may not
+%% call \unwindfib. You may not call \dtor, explicitly or implicitly, on a
+%% non-empty \fiber instance. With these restrictions, it is possible to use
+%% the \fiber facility without exception support.
 
 When an explicitly-launched fiber's \entryfn returns a non-empty \fiber
 instance, the running fiber is terminated. Control switches to the fiber
@@ -53,83 +55,83 @@ returns \cpp{false}) terminates the calling thread. This is true whether or
 not the thread's default fiber (see \nameref{fiber-context.implicit}) has
 terminated.
 
-\uabschnitt{stack unwinding}\label{unwinding}
-
-Stack unwinding caused by an exception, thread termination or fiber
-destruction exits functions on that stack without executing a \cpp{return} statement. Local variables
-that go out of scope may have destructors that must be called.
-The implementation must walk the stack and call the destructor for each object
-in every such stack frame.
-
-The C++ standard does not define how exception handling is implemented. Stack unwinding differs
-among different systems. The process of stack unwinding is described in the
-system ABI, for instance:
-\begin{itemize}
-    \item \emph{.eh\_frame}/\emph{personality routine} on SYS V AMD64 ABI\cite{SYSVAMD64} (de facto standard among Unix-like operating systems)
-    \item \emph{RUNTIME\_FUNCTION}/\emph{UNWIND\_INFO} on x64 Windows\cite{WinX64}
-    \item \emph{.pdata}/\emph{.xdata} on ARM64 Windows\cite{WinARM64}
-\end{itemize}
-
-\paragraph{SYS V AMD64 unwind library}
-is based on DWARF CFI (call frame information) that are stored in the \emph{.eh\_frame} section.
-Unwinding happens under following circumstances:
-\begin{itemize}
-    \item A C++ exception has been thrown
-    \item unwinding is forced by an external agent (longjmp for instance)
-\end{itemize}
-\uwforced takes a \foreignex (non-C++ exception; for instance Java or GO) and walks the stack frame by frame
-inspecting the \emph{unwind tables} for cleanup functions (for instance destructors of
-local variables) and catch blocks.
-
-\uwforced calls a \emph{personality routine} (\cpp{__gxx_personality_v0()} for GCC).\footnote{The
-personality routine passed by a specific runtime serves as interface between system unwinding library
-and language specific exception handling (not only C++; GO and Java are also supported). It is always invoked via pointer (saved
-as a function pointer in \ehframe\xspace for each stack frame).}
-\uwforced takes a stop function that controls the termination of the unwinding
-(reaching end of stack for fibers).
-The stop function intercepts calls to the personality routine, letting the external
-agent override the defaults of the stack frame's personality routine.\footnote{As
-a consequence the C++ personality routine deals only with C++ exceptions;
-it does not need to know anything specific about unwinding done by an external
-agent such as fiber or pthreads cancellation.}
-When the destination frame (last frame on fiber
-stack) is reached, control jumps back to the caller without further popping
-the stack.
-
-The code snippet below is a proof of concept available at \href{https://github.com/boostorg/context/tree/p0876r6}{Boost.Context branch p0876r6}.
-\cppf{unwind}
-\cpp{fiber_unwind()} is called by \unwindfib or \dtor and starts the stack unwinding.
-The foreign exception \cpp{foreign_unwind_ex}\footnote{setting member variable makes \cpp{foreign_unwind_ex} a foreign exception}
-is allocated and passed as parameter to the unwinding library. Function \cpp{fiber_unwind_stop()} transfers execution control
-to the calling fiber once the last stack frame has been unwound.
-
-\subparagraph{non-catchable \foreignex}
-\unwindfib uses a non-C++ \foreignex to force stack unwinding.
-As stated in the \emph{SYS V AMD64 ABI}\cite{SYSVAMD64} standard:
-"A runtime is not allowed to catch an exception if the \cpp{_UA_FORCE_UNWIND} flag was passed to the personality routine."
-and "... since it is not possible to determine if a given catch clause will re-throw or not without executing it ...", the
-\foreignex must not be catchable by C++ \cpp{try-catch} blocks.
-
-As a consequence, \curex can not return a \cpp{std::exception\_ptr} pointing
-to a \foreignex.
-
-In order to detect if stack unwinding is currently in progress \uncex returns \cpp{true} and\\
-\uncexs counts the \foreignex.
-
-The rationale for moving to an uncatchable exception is further explained in
-the \nameref{history}.
-
-The specific characteristics of a \foreignex:
-
-\begin{itemize}
-    \item Throwing the \foreignex can only be effected by the \fiber
-    facility. The proposed \unwindfib function is the only way to cause that
-    explicitly.
-    \item The ultimate "catch" -- the point at which stack unwinding stops --
-    is likewise determined by the \fiber facility. There is no explicit syntax
-    for this.
-    \item Along the way, as with a normal C++ exception, every object in every
-    stack frame is destroyed.
+%% \uabschnitt{stack unwinding}\label{unwinding}
+%% 
+%% Stack unwinding caused by an exception, thread termination or fiber
+%% destruction exits functions on that stack without executing a \cpp{return} statement. Local variables
+%% that go out of scope may have destructors that must be called.
+%% The implementation must walk the stack and call the destructor for each object
+%% in every such stack frame.
+%% 
+%% The C++ standard does not define how exception handling is implemented. Stack unwinding differs
+%% among different systems. The process of stack unwinding is described in the
+%% system ABI, for instance:
+%% \begin{itemize}
+%%     \item \emph{.eh\_frame}/\emph{personality routine} on SYS V AMD64 ABI\cite{SYSVAMD64} (de facto standard among Unix-like operating systems)
+%%     \item \emph{RUNTIME\_FUNCTION}/\emph{UNWIND\_INFO} on x64 Windows\cite{WinX64}
+%%     \item \emph{.pdata}/\emph{.xdata} on ARM64 Windows\cite{WinARM64}
+%% \end{itemize}
+%% 
+%% \paragraph{SYS V AMD64 unwind library}
+%% is based on DWARF CFI (call frame information) that are stored in the \emph{.eh\_frame} section.
+%% Unwinding happens under following circumstances:
+%% \begin{itemize}
+%%     \item A C++ exception has been thrown
+%%     \item unwinding is forced by an external agent (longjmp for instance)
+%% \end{itemize}
+%% \uwforced takes a \foreignex (non-C++ exception; for instance Java or GO) and walks the stack frame by frame
+%% inspecting the \emph{unwind tables} for cleanup functions (for instance destructors of
+%% local variables) and catch blocks.
+%% 
+%% \uwforced calls a \emph{personality routine} (\cpp{__gxx_personality_v0()} for GCC).\footnote{The
+%% personality routine passed by a specific runtime serves as interface between system unwinding library
+%% and language specific exception handling (not only C++; GO and Java are also supported). It is always invoked via pointer (saved
+%% as a function pointer in \ehframe\xspace for each stack frame).}
+%% \uwforced takes a stop function that controls the termination of the unwinding
+%% (reaching end of stack for fibers).
+%% The stop function intercepts calls to the personality routine, letting the external
+%% agent override the defaults of the stack frame's personality routine.\footnote{As
+%% a consequence the C++ personality routine deals only with C++ exceptions;
+%% it does not need to know anything specific about unwinding done by an external
+%% agent such as fiber or pthreads cancellation.}
+%% When the destination frame (last frame on fiber
+%% stack) is reached, control jumps back to the caller without further popping
+%% the stack.
+%% 
+%% The code snippet below is a proof of concept available at \href{https://github.com/boostorg/context/tree/p0876r6}{Boost.Context branch p0876r6}.
+%% \cppf{unwind}
+%% \cpp{fiber_unwind()} is called by \unwindfib or \dtor and starts the stack unwinding.
+%% The foreign exception \cpp{foreign_unwind_ex}\footnote{setting member variable makes \cpp{foreign_unwind_ex} a foreign exception}
+%% is allocated and passed as parameter to the unwinding library. Function \cpp{fiber_unwind_stop()} transfers execution control
+%% to the calling fiber once the last stack frame has been unwound.
+%% 
+%% \subparagraph{non-catchable \foreignex}
+%% \unwindfib uses a non-C++ \foreignex to force stack unwinding.
+%% As stated in the \emph{SYS V AMD64 ABI}\cite{SYSVAMD64} standard:
+%% "A runtime is not allowed to catch an exception if the \cpp{_UA_FORCE_UNWIND} flag was passed to the personality routine."
+%% and "... since it is not possible to determine if a given catch clause will re-throw or not without executing it ...", the
+%% \foreignex must not be catchable by C++ \cpp{try-catch} blocks.
+%% 
+%% As a consequence, \curex can not return a \cpp{std::exception\_ptr} pointing
+%% to a \foreignex.
+%% 
+%% In order to detect if stack unwinding is currently in progress \uncex returns \cpp{true} and\\
+%% \uncexs counts the \foreignex.
+%% 
+%% The rationale for moving to an uncatchable exception is further explained in
+%% the \nameref{history}.
+%% 
+%% The specific characteristics of a \foreignex:
+%% 
+%% \begin{itemize}
+%%     \item Throwing the \foreignex can only be effected by the \fiber
+%%     facility. The proposed \unwindfib function is the only way to cause that
+%%     explicitly.
+%%     \item The ultimate "catch" -- the point at which stack unwinding stops --
+%%     is likewise determined by the \fiber facility. There is no explicit syntax
+%%     for this.
+%%     \item Along the way, as with a normal C++ exception, every object in every
+%%     stack frame is destroyed.
 %%  \item \catchall clauses along the way are executed, but:
 %%  \begin{itemize}
 %%      \item \cpp{throw;} resumes stack unwinding, as usual
@@ -139,60 +141,60 @@ The specific characteristics of a \foreignex:
 %%      exception engages Undefined Behavior
 %%  \end{itemize}
 %%  \item \cpp{catch (}\emph{anything else}\cpp{)}
-    \item \cpp{catch} clauses along the way are ignored.
-\end{itemize}
-
-\zs{The system's exception handling, i.e. its unwinding framework, is used to clean up the stack
-of a fiber by using a foreign exception that is not catchable by C++ \cpp{try-catch} blocks.}
-
-Since unwinding a fiber's stack requires destroying objects declared in stack
-frames,
-%% and may involve executing \catchall clauses,
-it is worth pointing out that destroying a non-empty \fiber on a thread other
-than the thread on which it was last resumed will run those object destructors
-%% and \catchall clauses
-on the thread destroying the \fiber instance.
-
-As a consequence, destroying a \fiber instance representing a thread's default
-fiber (see \nameref{fiber-context.implicit})
-from any other thread engages Undefined Behavior.\footnote{One unobvious case
-would be if a fiber running on non-\main thread \cpp{T} stores a \fiber
-representing \cpp{T}'s default fiber in a static variable, whether
-module-scope or function-scope. That variable will be destroyed at program
-termination, probably on a thread other than \cpp{T}.}
-
-\subparagraph{marker frame}
-
-The \fiber facility behaves as if there is an implicit top-level function above
-each explicit fiber's \entryfn. (See \nameref{fiber-context.implicit}) This
-top-level function serves to delimit stack unwinding. Once the stack has been
-unwound to that point, it is as if control returns to the implicit top-level function. The
-implicit top-level function is conceptually responsible for freeing the explicit fiber's
-stack memory and for resuming the \fiber designated as the next fiber.
-
-\subparagraph{destroying a \fiber representing a thread's default fiber}
-
-Similarly, the C++ runtime behaves as if there is a stack marker at or above \main (and
-each explicitly-launched thread's \entryfn) that serves to delimit stack
-unwinding due to the \foreignex. Unlike an explicit fiber's top-level
-function, though, the conceptual top-level function on a thread's default fiber
-does \emph{not} deallocate that fiber's stack: the OS, which provided the
-stack in the first place, will do that.
-
-Unwinding the stack belonging to a thread's default fiber leaves the stack
-allocated but unreachable. That thread may continue to execute explict fibers
-as long as desired.
-
-Ultimately, however, it must be possible to exit a fiber in such as way as to
-terminate the calling thread. Returning an empty \fiber instance from
-a fiber's \entryfn terminates the running thread. Consequently, passing an
-empty \fiber instance to \unwindfib also terminates the calling thread.
-
-The \fiber facility does not defend against the case in which a thread's
-default fiber suspends (rather than terminating), but the explicit fiber it
-resumes ultimately causes thread termination in either of the ways described
-above. A higher-level library built on \fiber can provide a scheduler.
-The \fiber facility intentionally does not.
-
-The conceptual top-level function above \main, given an empty \fiber instance to resume,
-terminates the whole process instead of that one thread.
+%%     \item \cpp{catch} clauses along the way are ignored.
+%% \end{itemize}
+%% 
+%% \zs{The system's exception handling, i.e. its unwinding framework, is used to clean up the stack
+%% of a fiber by using a foreign exception that is not catchable by C++ \cpp{try-catch} blocks.}
+%% 
+%% Since unwinding a fiber's stack requires destroying objects declared in stack
+%% frames,
+%% %% and may involve executing \catchall clauses,
+%% it is worth pointing out that destroying a non-empty \fiber on a thread other
+%% than the thread on which it was last resumed will run those object destructors
+%% %% and \catchall clauses
+%% on the thread destroying the \fiber instance.
+%% 
+%% As a consequence, destroying a \fiber instance representing a thread's default
+%% fiber (see \nameref{fiber-context.implicit})
+%% from any other thread engages Undefined Behavior.\footnote{One unobvious case
+%% would be if a fiber running on non-\main thread \cpp{T} stores a \fiber
+%% representing \cpp{T}'s default fiber in a static variable, whether
+%% module-scope or function-scope. That variable will be destroyed at program
+%% termination, probably on a thread other than \cpp{T}.}
+%% 
+%% \subparagraph{marker frame}
+%% 
+%% The \fiber facility behaves as if there is an implicit top-level function above
+%% each explicit fiber's \entryfn. (See \nameref{fiber-context.implicit}) This
+%% top-level function serves to delimit stack unwinding. Once the stack has been
+%% unwound to that point, it is as if control returns to the implicit top-level function. The
+%% implicit top-level function is conceptually responsible for freeing the explicit fiber's
+%% stack memory and for resuming the \fiber designated as the next fiber.
+%% 
+%% \subparagraph{destroying a \fiber representing a thread's default fiber}
+%% 
+%% Similarly, the C++ runtime behaves as if there is a stack marker at or above \main (and
+%% each explicitly-launched thread's \entryfn) that serves to delimit stack
+%% unwinding due to the \foreignex. Unlike an explicit fiber's top-level
+%% function, though, the conceptual top-level function on a thread's default fiber
+%% does \emph{not} deallocate that fiber's stack: the OS, which provided the
+%% stack in the first place, will do that.
+%% 
+%% Unwinding the stack belonging to a thread's default fiber leaves the stack
+%% allocated but unreachable. That thread may continue to execute explict fibers
+%% as long as desired.
+%% 
+%% Ultimately, however, it must be possible to exit a fiber in such as way as to
+%% terminate the calling thread. Returning an empty \fiber instance from
+%% a fiber's \entryfn terminates the running thread. Consequently, passing an
+%% empty \fiber instance to \unwindfib also terminates the calling thread.
+%% 
+%% The \fiber facility does not defend against the case in which a thread's
+%% default fiber suspends (rather than terminating), but the explicit fiber it
+%% resumes ultimately causes thread termination in either of the ways described
+%% above. A higher-level library built on \fiber can provide a scheduler.
+%% The \fiber facility intentionally does not.
+%% 
+%% The conceptual top-level function above \main, given an empty \fiber instance to resume,
+%% terminates the whole process instead of that one thread.


### PR DESCRIPTION
Instead, require a second fiber_context constructor parameter, an invocable which is called by ~fiber_context() for a non-empty instance.

This PR does *not* yet update code examples! Consider a section in front matter introducing a (non-`std`) `unwind_fiber()` function, a (non-`std`) `unwind_exception` and a top-level wrapper function that catches `unwind_exception`. `unwind_fiber()` can move its passed `fiber_context` instance to a heap `fiber_context`; `unwind_exception` can bind a `std::shared_ptr<fiber_context>` so that `unwind_exception` remains copyable. The top-level wrapper function, on catching `unwind_exception`, extracts the bound `shared_ptr` and returns the passed `fiber_context`.

Then we could redo all the code examples in terms of those entities.

(Derive an `example_fiber_context` from `std::fiber_context`? `example_fiber_context`'s constructor would accept just the *entry-function*, passing that *entry-function* and `unwind_fiber` to its base-class constructor.)

This PR also adds a `rev` script to update the base P0876 document to the next revision.