### PR TITLE
Update code examples with cancellation functions.

### DIFF
--- a/D0876R7.tex
+++ b/D0876R7.tex
@@ -60,7 +60,7 @@
 \small
 \begin{tabbing}
     Document number: \= D0876R7\\
-    Date:            \> 2019-07-15\\
+    Date:            \> 2019-07-16\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> SG1\\
@@ -76,6 +76,7 @@
 
 \input{history}
 \input{abstract}
+\input{for_examples}
 \input{control_transfer}
 \input{first_class}
 \input{stack_management}

--- a/api.tex
+++ b/api.tex
@@ -118,7 +118,7 @@ since the OS will do that.
 
 \cppf{fiber}
 
-\mbrhdr{(constructor)}
+\mbrhdr{(constructor)}\label{constructor}
 constructs new \cpp{fiber\_context}
 
 \begin{tabular}{ l l }

--- a/code/assert_cancel.cpp
+++ b/code/assert_cancel.cpp
@@ -1,0 +1,7 @@
+// assert_cancel() is a cancellation function for use when you're quite sure
+// that the invoker will preserve every fiber_context representing this fiber
+// until it has voluntarily returned from its top-level function. Accidentally
+// destroying any fiber_context representing this fiber is a programming error.
+std::fiber_context assert_cancel(std::fiber_context&&) {
+    assert(false);
+}

--- a/code/asymmetric_op.cpp
+++ b/code/asymmetric_op.cpp
@@ -1,6 +1,7 @@
+// hypothetical API
 fiber_context f4{[]{
     self::suspend();
-};
+}};
 fiber_context f3{[&f4]{
     f4.resume();
     self::suspend();

--- a/code/generator.cpp
+++ b/code/generator.cpp
@@ -1,5 +1,5 @@
 int a;
-std::fiber_context g{[&a](std::fiber_context&& m){
+std::fiber_context g{launch([&a](std::fiber_context&& m){
     a=0;
     int b=1;
     for(;;){
@@ -9,7 +9,7 @@ std::fiber_context g{[&a](std::fiber_context&& m){
         b=next;
     }
     return std::move(m);
-}};
+})};
 std::vector<int> v(10);
 std::generate(v.begin(), v.end(), [&a,&g]() mutable {
     g=std::move(g).resume();

--- a/code/initial_resume_with.cpp
+++ b/code/initial_resume_with.cpp
@@ -1,6 +1,6 @@
 fiber_context topfunc(fiber_context&& prev);
 fiber_context injected(fiber_context&& prev);
 
-fiber_context f(topfunc);
+fiber_context f(launch(topfunc));
 // topfunc() has not yet been entered
 std::move(f).resume_with(injected);

--- a/code/launch.cpp
+++ b/code/launch.cpp
@@ -1,0 +1,46 @@
+// unwind_exception is an exception used internally by launch() to unwind the
+// stack of a suspended fiber when the referencing fiber_context instance is
+// destroyed.
+class unwind_exception: public std::runtime_error {
+public:
+    unwind_exception(std::fiber_context&& previous):
+        std::runtime_error("unwinding std::fiber_context"),
+        mPrevious(std::make_shared<std::fiber_context>(previous)) {}
+
+    std::shared_ptr<std::fiber_context> get_previous() const { return mPrevious; }
+
+private:
+    // Directly storing fiber_context would make unwind_exception move-only.
+    // Instead, store a shared_ptr so unwind_exception remains copyable.
+    std::shared_ptr<std::fiber_context> mPrevious;
+};
+
+// launch() is a factory function that returns a fiber_context representing a
+// new fiber that will run the passed entry_function. It implicitly provides a
+// top-level wrapper and a cancellation-function. If some fiber_context
+// representing this new fiber is eventually destroyed, ~fiber_context() will
+// call this cancellation-function, which will throw unwind_exception. The
+// top-level wrapper will catch it and return the bound fiber_context, thereby
+// resuming the fiber that called ~fiber_context().
+template <typename Fn>
+std::fiber_context launch(Fn&& entry_function) {
+    return std::fiber_context(
+        // entry-function passed to std::fiber_context constructor binds
+        // entry_function, calls it within try/catch, catches
+        // unwind_exception, extracts its shared_ptr<fiber_context>,
+        // dereferences it and returns that fiber_context.
+        [entry=std::move(entry_function)]
+        (std::fiber_context&& previous) {
+            try {
+                return entry(std::move(previous));
+            }
+            catch (const unwind_exception& unwind) {
+                return *unwind.get_previous();
+            }
+        },
+        // cancellation-function passed to std::fiber_context constructor
+        // throws unwind_exception, binding passed fiber_context instance.
+        [](std::fiber_context&& previous) {
+            throw unwind_exception(std::move(previous));
+        });
+}

--- a/code/ontop.cpp
+++ b/code/ontop.cpp
@@ -8,7 +8,7 @@ fiber_context f{[&data](fiber_context&& m){
     m=std::move(m).resume();
     std::cout << "f1: entered third time: " << data << std::endl;
     return std::move(m);
-}};
+}, assert_cancel};
 f=std::move(f).resume();
 std::cout << "f1: returned first time: " << data << std::endl;
 data+=1;

--- a/code/passing_lambda.cpp
+++ b/code/passing_lambda.cpp
@@ -4,7 +4,7 @@ std::fiber_context lambda{[&i](fiber_context&& caller){
     i+=1;
     caller=std::move(caller).resume();
     return std::move(caller);
-}};
+}, assert_cancel};
 lambda=std::move(lambda).resume();
 std::cout << "i==" << i << std::endl;
 lambda=std::move(lambda).resume();

--- a/code/return_from_resume_inplace.cpp
+++ b/code/return_from_resume_inplace.cpp
@@ -7,7 +7,7 @@ int main(){
             std::move(f1).resume();
         }
         return {};
-    }};
+    }, assert_cancel};
     f2=fiber_context{[&](fiber_context&& f)->fiber_context{
         f1=std::move(f);
         for(;;){
@@ -15,14 +15,14 @@ int main(){
             std::move(f3).resume();
         }
         return {};
-    }};
+    }, assert_cancel};
     f1=fiber_context{[&](fiber_context&& /*main*/)->fiber_context{
         for(;;){
             std::cout << "f1 ";
             std::move(f2).resume();
         }
         return {};
-    }};
+    }, assert_cancel};
     std::move(f1).resume();
     return 0;
 }

--- a/code/return_from_resume_invalid.cpp
+++ b/code/return_from_resume_invalid.cpp
@@ -7,7 +7,7 @@ int main(){
             f2=std::move(f1).resume();
         }
         return {};
-    }};
+    }, assert_cancel};
     f2=fiber_context{[&](fiber_context&& f)->fiber_context{
         f1=std::move(f);
         for(;;){
@@ -15,14 +15,14 @@ int main(){
             f1=std::move(f3).resume();
         }
         return {};
-    }};
+    }, assert_cancel};
     f1=fiber_context{[&](fiber_context&& /*main*/)->fiber_context{
         for(;;){
             std::cout << "f1 ";
             f3=std::move(f2).resume();
         }
         return {};
-    }};
+    }, assert_cancel};
     std::move(f1).resume();
     return 0;
 }

--- a/code/suspender.cpp
+++ b/code/suspender.cpp
@@ -1,8 +1,8 @@
-fiber_context f([](fiber_context&& caller){
+fiber_context f(launch([](fiber_context&& caller){
     // ...
     std::move(caller).resume();
     // ...
-});
+}));
 
 fiber_context fn(fiber_context&&);
 

--- a/code/symmetric_op.cpp
+++ b/code/symmetric_op.cpp
@@ -1,15 +1,15 @@
 fiber_context* pf1;
 fiber_context f4{[&pf1]{
     pf1->resume();
-};
+}, assert_cancel};
 fiber_context f3{[&f4]{
     f4.resume();
-}};
+}, assert_cancel};
 fiber_context f2{[&f3]{
     f3.resume();
-}};
+}, assert_cancel};
 fiber_context f1{[&f2]{
     f2.resume();
-}};
+}, assert_cancel};
 pf1=&f1;
 f1.resume();

--- a/code/synthesized_foo.cpp
+++ b/code/synthesized_foo.cpp
@@ -1,9 +1,9 @@
 void foo(){
-    fiber_context f{[](fiber_context&& m){
+    fiber_context f{launch([](fiber_context&& m){
         m=std::move(m).resume(); // switch to `foo()`
         m=std::move(m).resume(); // switch to `foo()`
         ...
-    }};
+    })};
     f=std::move(f).resume(); // start `f`
     f=std::move(f).resume(); // resume `f`
 }

--- a/code/synthesized_main.cpp
+++ b/code/synthesized_main.cpp
@@ -1,8 +1,8 @@
 int main(){
-    fiber_context f{[](fiber_context&& m){
+    fiber_context f{launch([](fiber_context&& m){
         m=std::move(m).resume(); // switch to `main()`
         ...
-    }};
+    })};
     f=std::move(f).resume(); // resume `f`
     return 0;
 }

--- a/code/terminating_fiber.cpp
+++ b/code/terminating_fiber.cpp
@@ -1,7 +1,7 @@
 int main(){
     fiber_context f{[](fiber_context&& m){
         return std::move(m); // resume `main()` by returning `m`
-    }};
+    }, assert_cancel};
     std::move(f).resume(); // resume `f`
     return 0;
 }

--- a/code/terminating_fiber_complex.cpp
+++ b/code/terminating_fiber_complex.cpp
@@ -4,12 +4,12 @@ int main(){
         std::cout << "f1: entered first time" << std::endl;
         assert(!f);
         return std::move(m); // resume (main-)fiber that has started `f2`
-    }};
+    }, assert_cancel};
     fiber_context f2{[&](fiber_context&& f){
         std::cout << "f2: entered first time" << std::endl;
         m=std::move(f); // preserve `f` (== suspended main())
         return std::move(f1);
-    }};
+    }, assert_cancel};
     std::move(f2).resume();
     std::cout << "main: done" << std::endl;
     return 0;


### PR DESCRIPTION
Introduce a new section "code common to examples in this paper" presenting
assert_cancel(), a cancellation function that asserts if it is ever reached,
and launch(), a factory function that provides an entry-function wrapper and a
cancellation function and returns a new fiber_context instance.

Update code examples to either pass assert_cancel to fiber_context constructor
or use launch() factory function.