### PR TITLE
Changes to R7 suggested by Chris Kohlhoff

### DIFF
--- a/D0876R7.tex
+++ b/D0876R7.tex
@@ -60,7 +60,7 @@
 \small
 \begin{tabbing}
     Document number: \= D0876R7\\
-    Date:            \> 2019-07-16\\
+    Date:            \> 2019-07-18\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> SG1\\

--- a/code/assert_cancel.cpp
+++ b/code/assert_cancel.cpp
@@ -1,7 +1,7 @@
-// assert_cancel() is a cancellation function for use when you're quite sure
+// assert_on_cancel() is a cancellation function for use when you're quite sure
 // that the invoker will preserve every fiber_context representing this fiber
 // until it has voluntarily returned from its top-level function. Accidentally
 // destroying any fiber_context representing this fiber is a programming error.
-std::fiber_context assert_cancel(std::fiber_context&&) {
+std::fiber_context assert_on_cancel(std::fiber_context&&) {
     assert(false);
 }

--- a/code/ontop.cpp
+++ b/code/ontop.cpp
@@ -8,7 +8,7 @@ fiber_context f{[&data](fiber_context&& m){
     m=std::move(m).resume();
     std::cout << "f1: entered third time: " << data << std::endl;
     return std::move(m);
-}, assert_cancel};
+}, assert_on_cancel};
 f=std::move(f).resume();
 std::cout << "f1: returned first time: " << data << std::endl;
 data+=1;

--- a/code/passing_lambda.cpp
+++ b/code/passing_lambda.cpp
@@ -4,7 +4,7 @@ std::fiber_context lambda{[&i](fiber_context&& caller){
     i+=1;
     caller=std::move(caller).resume();
     return std::move(caller);
-}, assert_cancel};
+}, assert_on_cancel};
 lambda=std::move(lambda).resume();
 std::cout << "i==" << i << std::endl;
 lambda=std::move(lambda).resume();

--- a/code/return_from_resume_inplace.cpp
+++ b/code/return_from_resume_inplace.cpp
@@ -7,7 +7,7 @@ int main(){
             std::move(f1).resume();
         }
         return {};
-    }, assert_cancel};
+    }, assert_on_cancel};
     f2=fiber_context{[&](fiber_context&& f)->fiber_context{
         f1=std::move(f);
         for(;;){
@@ -15,14 +15,14 @@ int main(){
             std::move(f3).resume();
         }
         return {};
-    }, assert_cancel};
+    }, assert_on_cancel};
     f1=fiber_context{[&](fiber_context&& /*main*/)->fiber_context{
         for(;;){
             std::cout << "f1 ";
             std::move(f2).resume();
         }
         return {};
-    }, assert_cancel};
+    }, assert_on_cancel};
     std::move(f1).resume();
     return 0;
 }

--- a/code/return_from_resume_invalid.cpp
+++ b/code/return_from_resume_invalid.cpp
@@ -7,7 +7,7 @@ int main(){
             f2=std::move(f1).resume();
         }
         return {};
-    }, assert_cancel};
+    }, assert_on_cancel};
     f2=fiber_context{[&](fiber_context&& f)->fiber_context{
         f1=std::move(f);
         for(;;){
@@ -15,14 +15,14 @@ int main(){
             f1=std::move(f3).resume();
         }
         return {};
-    }, assert_cancel};
+    }, assert_on_cancel};
     f1=fiber_context{[&](fiber_context&& /*main*/)->fiber_context{
         for(;;){
             std::cout << "f1 ";
             f3=std::move(f2).resume();
         }
         return {};
-    }, assert_cancel};
+    }, assert_on_cancel};
     std::move(f1).resume();
     return 0;
 }

--- a/code/symmetric_op.cpp
+++ b/code/symmetric_op.cpp
@@ -1,15 +1,15 @@
 fiber_context* pf1;
 fiber_context f4{[&pf1]{
     pf1->resume();
-}, assert_cancel};
+}, assert_on_cancel};
 fiber_context f3{[&f4]{
     f4.resume();
-}, assert_cancel};
+}, assert_on_cancel};
 fiber_context f2{[&f3]{
     f3.resume();
-}, assert_cancel};
+}, assert_on_cancel};
 fiber_context f1{[&f2]{
     f2.resume();
-}, assert_cancel};
+}, assert_on_cancel};
 pf1=&f1;
 f1.resume();

--- a/code/terminating_fiber.cpp
+++ b/code/terminating_fiber.cpp
@@ -1,7 +1,7 @@
 int main(){
     fiber_context f{[](fiber_context&& m){
         return std::move(m); // resume `main()` by returning `m`
-    }, assert_cancel};
+    }, assert_on_cancel};
     std::move(f).resume(); // resume `f`
     return 0;
 }

--- a/code/terminating_fiber_complex.cpp
+++ b/code/terminating_fiber_complex.cpp
@@ -4,12 +4,12 @@ int main(){
         std::cout << "f1: entered first time" << std::endl;
         assert(!f);
         return std::move(m); // resume (main-)fiber that has started `f2`
-    }, assert_cancel};
+    }, assert_on_cancel};
     fiber_context f2{[&](fiber_context&& f){
         std::cout << "f2: entered first time" << std::endl;
         m=std::move(f); // preserve `f` (== suspended main())
         return std::move(f1);
-    }, assert_cancel};
+    }, assert_on_cancel};
     std::move(f2).resume();
     std::cout << "main: done" << std::endl;
     return 0;

--- a/for_examples.tex
+++ b/for_examples.tex
@@ -2,13 +2,13 @@
 
 The \fiber constructor accepts an \entryfn and a \cancelfn (see
 \nameref{constructor}). For purposes of the examples in this paper, assume a
-trivial \cpp{assert\_cancel()} function as shown:
+trivial \cpp{assert\_on\_cancel()} function as shown:
 
 \cppf{assert_cancel}
 
-When \cpp{assert\_cancel} is passed to a \fiber constructor as its \cancelfn,
+When \cpp{assert\_on\_cancel} is passed to a \fiber constructor as its \cancelfn,
 if a \fiber instance representing that fiber is destroyed,
-\cpp{assert\_cancel()} fails its \cpp{assert()}.
+\cpp{assert\_on\_cancel()} fails its \cpp{assert()}.
 
 Sometimes it is desirable to abandon a fiber without letting it run to
 completion. Consider an infinite generator. For such cases, assume a

--- a/history.tex
+++ b/history.tex
@@ -31,8 +31,9 @@ permissible, or convey to the fiber in question by any suitable means the need
 to clean up and terminate.
 
 Requiring the cancellation function is partly because it remains unclear what
-the default should be, and partly to allow specifying later that the default
-engages the new, imporved unwind facility.
+the default should be. This could be one of the questions to be answered by a
+TS. Moreover, the absence of a default permits specifying later that the
+default engages the new, improved unwind facility.
 
 Changes since P0876R5:
 
@@ -65,7 +66,6 @@ Problems resolved by discarding \unwindex:
           the program. It was possible for an exception implementation based
           on \cpp{thread\_local} to become confused by exceptions on different
           fibers on the same thread.
-    \item It is no longer possible to capture \unwindex with
-          \cpp{std::exception\_ptr} and migrate it to a different fiber -- or
-          a different thread.
+    \item It was possible to capture \unwindex with \cpp{std::exception\_ptr}
+          and migrate it to a different fiber -- or a different thread.
 \end{itemize}


### PR DESCRIPTION
The most pervasive is his idea that assert_on_cancel() is clearer than
assert_cancel(). The others are minor editorial issues.