### PR TITLE
 P0876R8 changes: remove cancelfn ctor arg; add unwind_fiber;

### DIFF
--- a/P0876R8.tex
+++ b/P0876R8.tex
@@ -59,7 +59,7 @@
 \begin{document}
 \small
 \begin{tabbing}
-    Document number: \= D0876R7\\
+    Document number: \= P0876R8\\
     Date:            \> 2019-07-19\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\

--- a/P0876R8.tex
+++ b/P0876R8.tex
@@ -60,7 +60,7 @@
 \small
 \begin{tabbing}
     Document number: \= P0876R8\\
-    Date:            \> 2019-07-19\\
+    Date:            \> 2019-08-03\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> SG1\\
@@ -76,7 +76,7 @@
 
 \input{history}
 \input{abstract}
-\input{for_examples}
+%%\input{for_examples}
 \input{control_transfer}
 \input{first_class}
 \input{stack_management}

--- a/abstract.tex
+++ b/abstract.tex
@@ -3,7 +3,7 @@
 This paper addresses concerns, questions and suggestions from the past meetings.
 The proposed API supersedes the former proposals N3985\cite{N3985},
 P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3}
-and P0876R6\cite{P0876R6}.
+and D0876R7\cite{D0876R7}.
 
 Because of name clashes with \emph{coroutine} from coroutine TS,
 \emph{execution context} from executor proposals and \emph{continuation} used

--- a/api.tex
+++ b/api.tex
@@ -69,8 +69,8 @@ when necessary, we speak of the thread on which a fiber was last resumed.
 
 \rSec3[fiber-context.toplevel]{Implicit Top-Level Function}
 
-On every explicit fiber, the behavior is equivalent to injecting an implicit top-level stack
-frame above the \entryfn passed to \fiber's constructor.
+On every explicit fiber, the behavior is equivalent to calling the \entryfn
+passed to \fiber's constructor from an implicit top-level function.
 %% If the fiber is later
 %% unwound, this conceptual top-level stack frame serves as delimiter: this point
 %% is where unwinding stops.
@@ -97,18 +97,19 @@ The conceptual top-level
 function for an implicit fiber does not deallocate the fiber's stack memory,
 since the OS will do that.
 
-\begin{itemize}
-    \item If a non-empty \fiber instance is returned to the conceptual top-level
+%% \begin{itemize}
+%%     \item
+If a non-empty \fiber instance is returned to the conceptual top-level
     function (for either an explicit or implicit fiber), the fiber represented
     by that \fiber instance is resumed.
-    \item If an empty \fiber instance is returned to the conceptual top-level
-    function for an explicit fiber, the calling thread is terminated.
-    \item If an empty \fiber instance is returned to the conceptual top-level
-    function for the default fiber of an explicit thread, that thread is
-    terminated.
-    \item If an empty \fiber instance is returned to the conceptual top-level
-    function above \main, the process is terminated.
-\end{itemize}
+%%     \item If an empty \fiber instance is returned to the conceptual top-level
+%%     function for an explicit fiber, the calling thread is terminated.
+%%     \item If an empty \fiber instance is returned to the conceptual top-level
+%%     function for the default fiber of an explicit thread, that thread is
+%%     terminated.
+%%     \item If an empty \fiber instance is returned to the conceptual top-level
+%%     function above \main, the process is terminated.
+%% \end{itemize}
 
 \rSec3[fiber-context.synopis]{Header <experimental/fiber\_context> synopsis}
 
@@ -128,8 +129,8 @@ constructs new \cpp{fiber\_context}
 
     \midrule
 
-    \cpp{template<typename Fn0, typename Fn1>}\\
-    \cpp{explicit fiber\_context(Fn0&& entry, Fn1&& cancel)} & (2)\\
+    \cpp{template<typename Fn>}\\
+    \cpp{explicit fiber\_context(Fn&& fn)} & (2)\\
 
     \midrule
 
@@ -145,11 +146,11 @@ constructs new \cpp{fiber\_context}
 \begin{description}
     \item[1)] this constructor instantiates an empty \fiber. Its \cpp{empty()} method
               returns \cpp{true}.
-    \item[2)] takes invocable objects [func.def] as arguments. Both \cpp{entry}
-              and \cpp{cancel} must have signature 
-              \cpp{fiber\_context fn(fiber\_context&&)}. This constructor template
-              shall not participate in overload resolution unless \cpp{Fn0} and \cpp{Fn1}
-              are \emph{Lvalue-Invocable} [func.wrap.func] for the argument
+    \item[2)] takes an invocable object [func.def] as
+              argument. The invocable must have signature \cpp{fiber\_context
+              fn(fiber\_context&&)}. This constructor template shall not
+              participate in overload resolution unless \cpp{Fn}
+              is \emph{Lvalue-Invocable} [func.wrap.func] for the argument
               type \cpp{std::fiber\_context&&} and the return type \fiber.\\
               \bfs{SG1:} Needs update to \cpp{Invocable} concept.
     \item[3)] moves underlying state to new \fiber
@@ -158,7 +159,7 @@ constructs new \cpp{fiber\_context}
 
 \remarks
 \begin{description}
-    \item[---] The entry-function \cpp{entry} is \emph{not} immediately entered.
+    \item[---] The entry-function \cpp{fn} is \emph{not} immediately entered.
               The stack and any other necessary resources are created
               on construction, but \cpp{fn} is entered
               only when \allresume is called.
@@ -167,41 +168,27 @@ constructs new \cpp{fiber\_context}
               is constrained only by the last thread that previously resumed
               it -- and that constraint is imposed by operations performed by
               the fiber, rather than by the \fiber facility itself.
-    \item[---] The entry-function \cpp{entry} passed to \fiber
+    \item[---] The entry-function \cpp{fn} passed to \fiber
               will be passed a synthesized \fiber instance representing the
               suspended caller of \allresume.
-    \item[---] The \cancelfn \cpp{cancel} is invoked only when a non-empty
-              \fiber instance is destroyed. See \cpp{\~fiber\_context()}.
 \end{description}
 
 \mbrhdr{\~fiber\_context()}
 
 \effects
 \begin{description}
-    \item[---] destroys a \fiber instance. If this instance represents a fiber
-              of execution (\cpp{empty()} returns \cpp{false}), then the fiber of
-              execution is destroyed too.
+    \item[---] destroys a \fiber instance.
 \end{description}
 
-\remarks
+\requires
 \begin{description}
-    \item[---] If \cpp{empty()} returns \cpp{false} at the time a \fiber
-               instance is destroyed, the destructor performs a call
-               equivalent to \cpp{resume\_from\_any\_thread\_with(cancellation-function)}.
-    \item[---] The \cancelfn should communicate to the fiber represented by \cpp{*this}
-               the requirement to terminate. \tsnote{It may, for example, throw an exception
-               or set some state visible to the fiber logic.}
-%%    \item[---] Destroying a suspended fiber causes its stack to be unwound --
-%%               equivalent to calling\\
-%%               \cpp{resume\_from\_any\_thread\_with(unwind\_fiber)}.
-%%    \item[---] The destructors of the stack variables on the suspended fiber
-%%               represented by \cpp{*this}
-%%%%, and relevant \catchall clauses,
-%%               are run on the thread calling \dtor.
-%%    \item[---] As a consequence, destroying a \fiber instance
-%%               representing an implicit fiber from some other
-%%               thread engages Undefined Behavior.
+    \item[---] \cpp{empty()} returns \cpp{true}.
 \end{description}
+
+\tsnote{If a \fiber instance to be destroyed is not yet empty, an application
+may pass to \someresumewith a function intended to convey to the suspended
+fiber the need to terminate voluntarily. For example, such a function may
+throw an exception, or set some state visible to the functions on that fiber.}
 
 \subparagraph*{operator=}
 moves the \fiber object
@@ -218,14 +205,9 @@ moves the \fiber object
     \midrule
 \end{tabular}
 
-\remarks
+\requires
 \begin{description}
-    \item[---] If \cpp{empty()} returns \cpp{false} before move-assignment is
-               called, \cpp{operator=()} performs a call
-               equivalent to\\ \cpp{resume\_from\_any\_thread\_with(cancellation-function)}.
-    \item[---] The \cancelfn should communicate to the fiber represented by \cpp{*this}
-               the requirement to terminate. \tsnote{It may, for example, throw an exception
-               or set some state visible to the fiber logic.}
+    \item[---] \cpp{empty()} returns \cpp{true}.
 \end{description}
 
 \effects
@@ -341,8 +323,6 @@ fiber, and the currently-running fiber suspends. These method names mean that
 the fiber represented by \cpp{*this} will be resumed whether or not it was
 last resumed on \currthread.}
 
-\tsnote{A suspended \cpp{fiber\_context} can be destroyed.}
-
 \tsnote{The returned \cpp{fiber\_context} indicates via \cpp{empty()} whether the previous active
 fiber has terminated (returned from \entryfn).}
 
@@ -380,8 +360,6 @@ was previously resumed.}
 \effects
 \begin{description}
     \item[---] \resumewith has the same semantics as \xtresumewith.
-    \item[---] In addition, \resumewith may validate that \currthread is the
-               same as \lastthread.
 \end{description}
 
 \begin{tabular}{ l l }
@@ -430,11 +408,10 @@ query whether \currthread can resume the suspended\\
         resume an implicit fiber from any thread other than its owning thread is Undefined Behavior.
     \item[---] \canxtresume returns \cpp{true} if \currthread is the same as \lastthread,
         or if the \fiber instance represents an explicit fiber.
-    \item[---] \canxtresume is not marked \cpp{const} because in at least one
+    \item[---] \canxtresume must not be called concurrently from multiple threads.
+        \tsnote{\canxtresume is not marked \cpp{const} because in at least one
         implementation, it requires an internal context switch. However, the
-        stack operations are effectively read-only. Nonetheless, if it is
-        possible for more than one thread to call \canxtresume concurrently on
-        the same non-empty \fiber instance, locking is the caller's responsibility.
+        stack operations are effectively read-only.}
 \end{description}
 
 \mbrhdr{bool can\_resume() noexcept}
@@ -446,11 +423,10 @@ instance may be resumed by \allresume.}
 
 \remarks
 \begin{description}
-    \item[---] \canresume is not marked \cpp{const} because in at least one
+    \item[---] \canxtresume must not be called concurrently from multiple threads.
+        \tsnote{\canxtresume is not marked \cpp{const} because in at least one
         implementation, it requires an internal context switch. However, the
-        stack operations are effectively read-only. Nonetheless, if it is
-        possible for more than one thread to call \canresume concurrently on
-        the same non-empty \fiber instance, locking is the caller's responsibility.
+        stack operations are effectively read-only.}
 \end{description}
 
 \subparagraph*{empty()}
@@ -485,47 +461,46 @@ test whether \fiber is empty
     \item[---] Exchanges the state of \cpp{*this} with \cpp{other}.
 \end{description}
 
-%% \rSec3[fiber-context.unwinding]{Function unwind\_fiber()}
-%% 
-%% \mbrhdr{[[ noreturn ]] void unwind\_fiber(fiber\_context&& other)}
-%% 
-%% \effects
-%% terminate the current running fiber.
-%% 
-%% \remarks
-%% \begin{description}
+\rSec3[fiber-context.unwinding]{Function unwind\_fiber()}
+
+\mbrhdr{[[ noreturn ]] void unwind\_fiber(fiber\_context&& other)}
+
+\effects
+terminate the current running fiber in an implementation-defined manner.
+
+\remarks
+\begin{description}
 %%     \item[---] The underlying Unwinding facility (for instance the unwind facility
 %%                described in \emph{System V ABI for AMD64}) unwinds the stack
 %%                to the implicit top-level stack frame and terminates the
 %%                current fiber as described above.
-%%     \item[---] Unwinding the fiber's stack causes its stack variables to be
-%%                destroyed.
+    \item[---] Termnating the fiber causes its stack variables to be destroyed.
 %%     \item[---] During this specific stack unwinding, 
-%% %% only \catchall clauses are executed. No other
+%% only \catchall clauses are executed. No other
 %%                no \cpp{catch} clauses are executed, not even \catchall.
-%%     \item[---] Once the running fiber has been fully unwound, \cpp{other} is
-%%                returned to the fiber's conceptual top-level function as
-%%                described in \nameref{fiber-context.toplevel}.
-%% %%  \item[---] Unwinding the fiber's stack causes relevant \catchall
-%% %%             clauses to be executed.
-%% %%  \item[---] During this specific stack unwinding, a \catchall
-%% %%             clause that does not execute a \cpp{throw;} statement behaves
-%% %%             as if it ended with a \cpp{throw;} statement.
-%% %%  \item[---] During this specific stack unwinding, a \catchall
-%% %%             clause that attempts to throw any C++ exception engages
-%% %%             Undefined Behavior.
-%% \end{description}
-%% 
-%% \params
-%% \begin{description}
-%%     \item[other] the \fiber to which to switch once the current fiber has terminated
-%% \end{description}
-%% 
-%% \returns
-%% \begin{description}
-%%     \item[---] None: \unwindfib does not return
-%% \end{description}
-%% 
+    \item[---] Once the running fiber has been terminated, \cpp{other} is
+               returned to the fiber's conceptual top-level function as
+               described in \nameref{fiber-context.toplevel}.
+%%  \item[---] Unwinding the fiber's stack causes relevant \catchall
+%%             clauses to be executed.
+%%  \item[---] During this specific stack unwinding, a \catchall
+%%             clause that does not execute a \cpp{throw;} statement behaves
+%%             as if it ended with a \cpp{throw;} statement.
+%%  \item[---] During this specific stack unwinding, a \catchall
+%%             clause that attempts to throw any C++ exception engages
+%%             Undefined Behavior.
+\end{description}
+
+\params
+\begin{description}
+    \item[other] the \fiber to which to switch once the current fiber has terminated
+\end{description}
+
+\returns
+\begin{description}
+    \item[---] None: \unwindfib does not return
+\end{description}
+
 %% \except
 %% \begin{description}
 %%     \item[---] None catchable by C++

--- a/code/assign_resumewith.cpp
+++ b/code/assign_resumewith.cpp
@@ -8,6 +8,6 @@ public:
         std::move(fila.f_).resume_with([this](fiber_context&& f)->fiber_context{
             f_=std::move(f);
             return {};
-        }
+        });
     }
 };

--- a/code/bind_cancelfn.cpp
+++ b/code/bind_cancelfn.cpp
@@ -1,0 +1,76 @@
+// cancellable is a wrapper class that binds a cancellation-function along
+// with an associated fiber_context. It uses the tactic seen earlier in the
+// example 'filament' class to continually update the fiber_context
+// representing the fiber of interest.
+template <typename CANCEL>
+class cancellable{
+private:
+    fiber_context       f_;
+    CANCEL              cancel_;
+
+public:
+    cancellable(fiber_context&& f, CANCEL cancel):
+        f_(std::move(f)),
+        cancel_(cancel)
+    {}
+
+    ~cancellable() {
+        std::move(f_).resume_with([this](fiber_context&& f)->fiber_context{
+            return cancel_(f);
+        });
+    }
+
+    void resume_next( cancellable& cable){
+        std::move(cable.f_).resume_with([this](fiber_context&& f)->fiber_context{
+            f_=std::move(f);
+            return {};
+        });
+    }
+};
+
+// unwind_exception is an exception used internally by launch() to unwind the
+// stack of a suspended fiber when the referencing fiber_context instance is
+// destroyed.
+class unwind_exception: public std::runtime_error {
+public:
+    unwind_exception(std::fiber_context&& previous):
+        std::runtime_error("unwinding std::fiber_context"),
+        previous_(std::make_shared<std::fiber_context>(std::move(previous))) {}
+
+    std::shared_ptr<std::fiber_context> get_previous() const { return previous_; }
+
+private:
+    // Directly storing fiber_context would make unwind_exception move-only.
+    // Instead, store a shared_ptr so unwind_exception remains copyable.
+    std::shared_ptr<std::fiber_context> previous_;
+};
+
+// launch() is a factory function that returns a cancellable representing a
+// new fiber that will run the passed entry_function. It implicitly provides a
+// top-level wrapper and a cancellation-function. If the cancellable
+// representing this new fiber is eventually destroyed, ~cancellable() will
+// call this cancellation-function, which will throw unwind_exception. The
+// top-level wrapper will catch it and return the bound fiber_context, thereby
+// resuming the fiber that called ~cancellable().
+template <typename Fn>
+cancellable launch(Fn&& entry_function) {
+    return cancellable(std::fiber_context(
+        // entry-function passed to std::fiber_context constructor binds
+        // entry_function, calls it within try/catch, catches
+        // unwind_exception, extracts its shared_ptr<fiber_context>,
+        // dereferences it and returns that fiber_context.
+        [entry=std::move(entry_function)]
+        (std::fiber_context&& previous) {
+            try {
+                return entry(std::move(previous));
+            }
+            catch (const unwind_exception& unwind) {
+                return *unwind.get_previous();
+            }
+        }),
+        // cancellation-function passed to cancellable constructor
+        // throws unwind_exception, binding passed fiber_context instance.
+        [](std::fiber_context&& previous) {
+            throw unwind_exception(std::move(previous));
+        });
+}

--- a/code/fiber.cpp
+++ b/code/fiber.cpp
@@ -6,8 +6,8 @@ class fiber_context {
 public:
     fiber_context() noexcept;
 
-    template<typename Fn0, typename Fn1>
-    explicit fiber_context(Fn0&& entry, Fn1&& cancel);
+    template<typename Fn>
+    explicit fiber_context(Fn&& fn);
 
     ~fiber_context();
 

--- a/code/generator.cpp
+++ b/code/generator.cpp
@@ -9,7 +9,7 @@ std::fiber_context g{[&a](std::fiber_context&& m){
         b=next;
     }
     return std::move(m);
-})};
+}};
 std::vector<int> v(10);
 std::generate(v.begin(), v.end(), [&a,&g]() mutable {
     g=std::move(g).resume();

--- a/code/generator.cpp
+++ b/code/generator.cpp
@@ -1,5 +1,5 @@
 int a;
-std::fiber_context g{launch([&a](std::fiber_context&& m){
+std::fiber_context g{[&a](std::fiber_context&& m){
     a=0;
     int b=1;
     for(;;){

--- a/code/initial_resume_with.cpp
+++ b/code/initial_resume_with.cpp
@@ -1,6 +1,6 @@
 fiber_context topfunc(fiber_context&& prev);
 fiber_context injected(fiber_context&& prev);
 
-fiber_context f(launch(topfunc));
+fiber_context f(topfunc);
 // topfunc() has not yet been entered
 std::move(f).resume_with(injected);

--- a/code/ontop.cpp
+++ b/code/ontop.cpp
@@ -8,7 +8,7 @@ fiber_context f{[&data](fiber_context&& m){
     m=std::move(m).resume();
     std::cout << "f1: entered third time: " << data << std::endl;
     return std::move(m);
-}, assert_on_cancel};
+}};
 f=std::move(f).resume();
 std::cout << "f1: returned first time: " << data << std::endl;
 data+=1;

--- a/code/passing_lambda.cpp
+++ b/code/passing_lambda.cpp
@@ -4,7 +4,7 @@ std::fiber_context lambda{[&i](fiber_context&& caller){
     i+=1;
     caller=std::move(caller).resume();
     return std::move(caller);
-}, assert_on_cancel};
+}};
 lambda=std::move(lambda).resume();
 std::cout << "i==" << i << std::endl;
 lambda=std::move(lambda).resume();

--- a/code/return_from_resume_inplace.cpp
+++ b/code/return_from_resume_inplace.cpp
@@ -7,7 +7,7 @@ int main(){
             std::move(f1).resume();
         }
         return {};
-    }, assert_on_cancel};
+    }};
     f2=fiber_context{[&](fiber_context&& f)->fiber_context{
         f1=std::move(f);
         for(;;){
@@ -15,14 +15,14 @@ int main(){
             std::move(f3).resume();
         }
         return {};
-    }, assert_on_cancel};
+    }};
     f1=fiber_context{[&](fiber_context&& /*main*/)->fiber_context{
         for(;;){
             std::cout << "f1 ";
             std::move(f2).resume();
         }
         return {};
-    }, assert_on_cancel};
+    }};
     std::move(f1).resume();
     return 0;
 }

--- a/code/return_from_resume_invalid.cpp
+++ b/code/return_from_resume_invalid.cpp
@@ -7,7 +7,7 @@ int main(){
             f2=std::move(f1).resume();
         }
         return {};
-    }, assert_on_cancel};
+    }};
     f2=fiber_context{[&](fiber_context&& f)->fiber_context{
         f1=std::move(f);
         for(;;){
@@ -15,14 +15,14 @@ int main(){
             f1=std::move(f3).resume();
         }
         return {};
-    }, assert_on_cancel};
+    }};
     f1=fiber_context{[&](fiber_context&& /*main*/)->fiber_context{
         for(;;){
             std::cout << "f1 ";
             f3=std::move(f2).resume();
         }
         return {};
-    }, assert_on_cancel};
+    }};
     std::move(f1).resume();
     return 0;
 }

--- a/code/suspender.cpp
+++ b/code/suspender.cpp
@@ -1,8 +1,8 @@
-fiber_context f(launch([](fiber_context&& caller){
+fiber_context f([](fiber_context&& caller){
     // ...
     std::move(caller).resume();
     // ...
-}));
+});
 
 fiber_context fn(fiber_context&&);
 

--- a/code/symmetric_op.cpp
+++ b/code/symmetric_op.cpp
@@ -1,15 +1,15 @@
 fiber_context* pf1;
 fiber_context f4{[&pf1]{
     pf1->resume();
-}, assert_on_cancel};
+};
 fiber_context f3{[&f4]{
     f4.resume();
-}, assert_on_cancel};
+}};
 fiber_context f2{[&f3]{
     f3.resume();
-}, assert_on_cancel};
+}};
 fiber_context f1{[&f2]{
     f2.resume();
-}, assert_on_cancel};
+}};
 pf1=&f1;
 f1.resume();

--- a/code/synopsis.cpp
+++ b/code/synopsis.cpp
@@ -8,6 +8,8 @@ inline namespace concurrency_v2 {
 
 class fiber_context;
 
+void unwind_fiber(fiber_context&& other);
+
 } // namespace concurrency_v2
 } // namespace experimental
 } // namespace std

--- a/code/synthesized_foo.cpp
+++ b/code/synthesized_foo.cpp
@@ -1,9 +1,9 @@
 void foo(){
-    fiber_context f{launch([](fiber_context&& m){
+    fiber_context f{[](fiber_context&& m){
         m=std::move(m).resume(); // switch to `foo()`
         m=std::move(m).resume(); // switch to `foo()`
         ...
-    })};
+    }};
     f=std::move(f).resume(); // start `f`
     f=std::move(f).resume(); // resume `f`
 }

--- a/code/synthesized_main.cpp
+++ b/code/synthesized_main.cpp
@@ -1,8 +1,8 @@
 int main(){
-    fiber_context f{launch([](fiber_context&& m){
+    fiber_context f{[](fiber_context&& m){
         m=std::move(m).resume(); // switch to `main()`
         ...
-    })};
+    }};
     f=std::move(f).resume(); // resume `f`
     return 0;
 }

--- a/code/terminating_fiber.cpp
+++ b/code/terminating_fiber.cpp
@@ -1,7 +1,7 @@
 int main(){
     fiber_context f{[](fiber_context&& m){
         return std::move(m); // resume `main()` by returning `m`
-    }, assert_on_cancel};
+    }};
     std::move(f).resume(); // resume `f`
     return 0;
 }

--- a/code/terminating_fiber_complex.cpp
+++ b/code/terminating_fiber_complex.cpp
@@ -4,12 +4,12 @@ int main(){
         std::cout << "f1: entered first time" << std::endl;
         assert(!f);
         return std::move(m); // resume (main-)fiber that has started `f2`
-    }, assert_on_cancel};
+    }};
     fiber_context f2{[&](fiber_context&& f){
         std::cout << "f2: entered first time" << std::endl;
         m=std::move(f); // preserve `f` (== suspended main())
         return std::move(f1);
-    }, assert_on_cancel};
+    }};
     std::move(f2).resume();
     std::cout << "main: done" << std::endl;
     return 0;

--- a/history.tex
+++ b/history.tex
@@ -23,7 +23,7 @@ a particular fiber earlier in the lifespan of the fiber, a struct serves. We
 have added an example to the front matter.
 
 A more compelling reason to avoid constructing an explicit fiber with
-a \cancelfn is that no implicit fiber has any such \cancelfn -- and the
+a \cancelfn is that no implicit fiber has any such \cancelfn\xspace -- and the
 consuming application cannot tell, a priori, whether a given \fiber instance
 represents an explicit or an implicit fiber. If \cpp{*this} represents an
 implicit fiber, what should the proposed \cpp{cancel()} member function do?

--- a/history.tex
+++ b/history.tex
@@ -1,7 +1,43 @@
 \abschnitt{Revision History}\label{history}
-This document supersedes P0876R6.
+This document supersedes D0876R7.
 
-Changes since P0876R6:
+\uabschnitt{Changes since D0876R7}
+
+\begin{itemize}
+    \item Cancellation function removed from \fiber constructor.
+    \item \unwindfib re-added, with implementation-defined behavior.
+    \item Added elaboration of \cpp{filament} example to bind cancellation
+          function.
+\end{itemize}
+
+P0876R8 diverges from the recommendations of the second SG1 round in Cologne
+2019. It does not introduce \cpp{cancel()} or \cpp{cancel\_from\_any\_thread()}
+member functions. In fact it removes the \cancelfn constructor argument.
+
+\fiber is intended as the lowest-level stackful context-switching API. Binding
+a \cancelfn on the fiber stack is a flourish rather than a necessity. It adds
+overhead in both space (on the fiber stack) and time (to traverse the stack to
+retrieve the \cancelfn). For this API, it suffices to pass the desired
+\cancelfn to \someresumewith. If it is important to associate a \cancelfn with
+a particular fiber earlier in the lifespan of the fiber, a struct serves. We
+have added an example to the front matter.
+
+A more compelling reason to avoid constructing an explicit fiber with
+a \cancelfn is that no implicit fiber has any such \cancelfn -- and the
+consuming application cannot tell, a priori, whether a given \fiber instance
+represents an explicit or an implicit fiber. If \cpp{*this} represents an
+implicit fiber, what should the proposed \cpp{cancel()} member function do?
+
+Passing a specific \cancelfn to \someresumewith avoids that problem.
+
+P0876R8 follows SG1 recommendation in making it Undefined Behavior to destroy
+(or assign to) a non-empty \fiber instance.
+
+\unwindfib is reintroduced with implementation-defined behavior to allow fiber
+cleanup leveraging implementation internals. Its use is entirely optional (and
+auditable). 
+
+\uabschnitt{Changes since P0876R6}
 
 \begin{itemize}
     \item Implicit stack unwinding (by non-C++ exception) removed.
@@ -35,7 +71,7 @@ the default should be. This could be one of the questions to be answered by a
 TS. Moreover, the absence of a default permits specifying later that the
 default engages the new, improved unwind facility.
 
-Changes since P0876R5:
+\uabschnitt{Changes since P0876R5}
 
 \begin{itemize}
     \item \cpp{std::unwind\_exception} removed.

--- a/references.tex
+++ b/references.tex
@@ -65,6 +65,10 @@
         \href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0876r6.pdf}
         {P0876R6: fibers without scheduler}
 
+    \bibitem{D0876R7}
+        \href{http://wiki.edg.com/pub/Wg21cologne2019/SG1/D0876R7.pdf}
+        {D0876R7: fibers without scheduler}
+
     \bibitem{coreguidlines}
         \href{http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Ri-global}
         {C++ Core Guidelines}

--- a/rev
+++ b/rev
@@ -48,11 +48,25 @@ echo "$oldrev URL: $oldurl"
 echo "Previous to $oldrev was $prevrev"
 
 git mv "$oldtex" "$newrev.tex"
-sed -i.tex~ "s/$oldrev/$newrev/" "$newrev.tex"
-sed -i.tex~ "s/$prevrev\\\\cite{$prevrev}/$oldrev\\\\cite{$oldrev}/" abstract.tex
-sed -i.tex~ -E "s/(supersedes |since )$prevrev/\\1$oldrev/" history.tex
+sed -i~ "s/$oldrev/$newrev/" "$newrev.tex"
+sed -i~ "s/$prevrev\\\\cite{$prevrev}/$oldrev\\\\cite{$oldrev}/" abstract.tex
 
-# This sed command needs a bit of explanation.
+# For 'This document supersedes $prevrev', just update to $oldrev.
+# For 'Changes since $prevrev', insert 'Changes since $oldrev' above it, with
+# a blank line separating the two.
+# H appends a newline character followed by the pattern space (the 'Changes
+# since $prevrev' line) to the (previously-empty) hold space.
+# Then update the pattern space to talk about 'Changes since $oldrev'.
+# G appends a newline character followed by the hold space to the pattern
+# space. The combination of those two newlines produces the desired blank
+# line.
+sed -i~ -E -f <(echo \
+"/(supersedes )$prevrev/s//\\1$oldrev/
+/Changes since $prevrev/{ H
+s/$prevrev/$oldrev/
+G
+}") history.tex
+
 # We want to inject a new \bibitem{$oldrev} block just like (and just after)
 # the \bibitem{$prevrev} block. Each such block is 4 lines long, including the
 # trailing blank line. So search for \bibitem{$prevrev}, then suck the next 3
@@ -64,7 +78,7 @@ sed -i.tex~ -E "s/(supersedes |since )$prevrev/\\1$oldrev/" history.tex
 # greedy, spans lines and will eat through the close } and the subsequent open
 # { and all the way up to the second }. Don't explicitly print the pattern
 # space again because that's implied (since we didn't specify the -n switch).
-sed -i.tex~ -f <(echo \
+sed -i~ -f <(echo \
 "/\bibitem{$prevrev}/{ N
 N
 N

--- a/stack.tex
+++ b/stack.tex
@@ -1,27 +1,33 @@
 \abschnitt{stack destruction}\label{destruction}
 
 On construction of a \fiber a stack is allocated. If the \entryfn returns,
-the stack will be destroyed. If the function has not yet returned and the
-destructor of the \fiber instance representing that context is called,
+the stack will be destroyed. If the function has not yet returned,
+the \fiber instance representing that fiber must not be destroyed.
+%% and the
+%% destructor of the \fiber instance representing that context is called,
 %% the stack will be unwound and destroyed.
-the calling program is responsible for unwinding the stack.
+%% the calling program is responsible for unwinding the stack.
 
-The fiber's \cancelfn is used to trigger cleanup.
+%% The fiber's \cancelfn is used to trigger cleanup.
 
-Consider a running fiber \cpp{f2} that destroys the \fiber instance
-representing \cpp{f1}.
+Before running fiber \cpp{f2} can correctly destroy a \fiber instance
+representing \cpp{f1}, it must ensure that \cpp{f1}'s \entryfn has returned.
+It might, for example, call \resumewith, passing \unwindfib.
 
-\cpp{f1}'s destructor, running on \cpp{f2}, implicitly calls member-function
-\resumewith, passing the fiber's \cancelfn as
-argument. Fiber \cpp{f1} will be temporarily resumed and the \cancelfn is
-invoked.
-
-The \cancelfn must communicate to fiber \cpp{f1} the need to terminate. It
-might throw an exception. It might set a distinguished value in some object
-tested by code on \cpp{f1}. In any case, fiber \cpp{f2} remains suspended
-in \cpp{f1}'s destructor until \cpp{f1}'s \entryfn returns (the \fiber
-instance synthesized for) \cpp{f2} -- or until \cpp{f2} is explicitly resumed
-in some other way.
+%% Consider a running fiber \cpp{f2} that destroys the \fiber instance
+%% representing \cpp{f1}.
+%% 
+%% \cpp{f1}'s destructor, running on \cpp{f2}, implicitly calls member-function
+%% \resumewith, passing the fiber's \cancelfn as
+%% argument. Fiber \cpp{f1} will be temporarily resumed and the \cancelfn is
+%% invoked.
+%% 
+%% The \cancelfn must communicate to fiber \cpp{f1} the need to terminate. It
+%% might throw an exception. It might set a distinguished value in some object
+%% tested by code on \cpp{f1}. In any case, fiber \cpp{f2} remains suspended
+%% in \cpp{f1}'s destructor until \cpp{f1}'s \entryfn returns (the \fiber
+%% instance synthesized for) \cpp{f2} -- or until \cpp{f2} is explicitly resumed
+%% in some other way.
 
 %% Function \unwindfib caches an instance of \fiber that
 %% represents \cpp{f2}, then unwinds \cpp{f1}'s stack

--- a/termination.tex
+++ b/termination.tex
@@ -36,6 +36,10 @@ terminate gracefully by returning from its top-level function.
 %% non-empty \fiber instance. With these restrictions, it is possible to use
 %% the \fiber facility without exception support.
 
+Alternatively, a running fiber may call \unwindfib, passing a non-empty \fiber
+instance. This is conceptually equivalent to returning that \fiber instance
+from the fiber's \entryfn.
+
 When an explicitly-launched fiber's \entryfn returns a non-empty \fiber
 instance, the running fiber is terminated. Control switches to the fiber
 indicated by the returned \fiber instance. The \entryfn may return (switch to)
@@ -49,11 +53,17 @@ am suspending; please resume me later.''
 \emph{Returning} a particular \fiber means: ``Please switch to the indicated
 fiber; and by the way, I am done.''
 
-The \emph{last} fiber on a particular thread has no non-empty \fiber to
-return. For this reason, returning an empty \fiber instance (\opbool
-returns \cpp{false}) terminates the calling thread. This is true whether or
-not the thread's default fiber (see \nameref{fiber-context.implicit}) has
-terminated.
+The code below illustrates a possible way to aggregate an arbitrary \cancelfn
+with a fiber of interest, along with a factory function providing an
+example \cancelfn.
+
+\cppf{bind_cancelfn}
+
+%% The \emph{last} fiber on a particular thread has no non-empty \fiber to
+%% return. For this reason, returning an empty \fiber instance (\opbool
+%% returns \cpp{false}) terminates the calling thread. This is true whether or
+%% not the thread's default fiber (see \nameref{fiber-context.implicit}) has
+%% terminated.
 
 %% \uabschnitt{stack unwinding}\label{unwinding}
 %% 


### PR DESCRIPTION
show example of a simple class aggregating a cancellation-function with a
fiber of interest.

Revert code examples to pre-R7 state.