### PR TITLE
'auto' return would allow launch() to return templated cancellable

### DIFF
--- a/code/bind_cancelfn.cpp
+++ b/code/bind_cancelfn.cpp
@@ -64,8 +64,8 @@ private:
 // top-level wrapper will catch it and return the bound fiber_context, thereby
 // resuming the fiber that called ~cancellable().
 template <typename Fn>
-cancellable launch(Fn&& entry_function) {
-    return cancellable{std::fiber_context(
+auto launch(Fn&& entry_function) {
+    return cancellable(std::fiber_context(
         // entry-function passed to std::fiber_context constructor binds
         // entry_function, calls it within try/catch, catches
         // unwind_exception, extracts its shared_ptr<fiber_context>,

--- a/code/bind_cancelfn.cpp
+++ b/code/bind_cancelfn.cpp
@@ -65,7 +65,7 @@ private:
 // resuming the fiber that called ~cancellable().
 template <typename Fn>
 auto launch(Fn&& entry_function) {
-    return cancellable(std::fiber_context(
+    return cancellable{std::fiber_context(
         // entry-function passed to std::fiber_context constructor binds
         // entry_function, calls it within try/catch, catches
         // unwind_exception, extracts its shared_ptr<fiber_context>,


### PR DESCRIPTION
if we decide to revert to storing the cancellation-function directly rather
than using std::function.