### PR TITLE
Update to D0876R12, no bundled stop_source, new make_fiber_context().

### DIFF
--- a/D0876R12.tex
+++ b/D0876R12.tex
@@ -59,11 +59,11 @@
 \begin{document}
 \small
 \begin{tabbing}
-    Document number: \= P0876R11\\
-    Date:            \> 2022-10-14\\
+    Document number: \= D0876R12\\
+    Date:            \> 2023-02-06\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
-    Audience:        \> LEWG, EWG\\
+    Audience:        \> LEWG\\
 \end{tabbing}
 
 \section*{\emph{fiber\_context} - fibers without scheduler}

--- a/abstract.tex
+++ b/abstract.tex
@@ -8,7 +8,7 @@ constructs such as stackful coroutines as well as cooperative multitasking
 
 This revision addresses concerns, questions and suggestions from the past meetings.
 The proposed API supersedes the former proposals N3985\cite{N3985},
-P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3} and P0876R10\cite{P0876R10}.
+P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3} and P0876R11\cite{P0876R11}.
 
 Because of name clashes with \emph{coroutine} from C++20,
 \emph{execution context} from executor proposals and \emph{continuation} used

--- a/acknowledgment.tex
+++ b/acknowledgment.tex
@@ -1,4 +1,5 @@
 \abschnitt{acknowledgments}
 
 The authors would like to thank Andrii Grynenko, Detlef Vollmann, Geoffrey Romer,
-Grigory Demchenko, Lee Howes, Daisy Sophia Hollman, Eric Fiselier and Yedidya Feldblum.
+Grigory Demchenko, Lee Howes, Daisy Sophia Hollman, Eric Fiselier, Yedidya
+Feldblum, Kirk Shoop and Lewis Baker.

--- a/api.tex
+++ b/api.tex
@@ -61,9 +61,9 @@ thread} is the thread of which that fiber is the default fiber. An explicit
 fiber has no owning thread. Instead, when necessary, we speak of the thread on
 which a fiber was first resumed.
 
-A fiber is explicitly instantiated by passing an \emph{\entryfn} to \fiber's
-constructor. This function is not entered until the first call to one of
-the \cpp{fiber\_context::resume()} family of methods.
+A fiber is constructed by passing an \emph{\entryfn} to \factory. This
+function is not entered until the first call to one of the
+\cpp{fiber\_context::resume()} family of methods.
 
 When a fiber is first entered, a synthesized non-empty \fiber instance
 representing the newly-suspended previous fiber is passed as a parameter to
@@ -137,45 +137,6 @@ If the fiber's \entryfn exits via an exception, \cpp{std::terminate} is called.
 \postcond
 \begin{description}
     \item[---] \cpp{empty()} returns \cpp{true}.
-    \item[---] \cpp{ssource.stop\_possible()} returns \cpp{false}.
-\end{description}
-
-\mbrhdr{template<typename F> explicit fiber\_context(F\&\& entry)}
-
-\constraints
-\begin{description}
-    \item[---] \cpp{remove\_cvref\_t<F>} is not the same type as \cpp{fiber\_context}.
-%%  \item[---] This constructor template shall not participate in overload
-%%            resolution unless \cpp{Fn}
-%%            is \emph{Lvalue-Invocable} [func.wrap.func] for the argument
-%%            type \cpp{std::fiber\_context&&} and the return type \fiber.
-\end{description}
-
-\mandates
-\begin{description}
-    \item[---] \cpp{is\_invocable\_v<decay\_t<F>, fiber\_context&&> ||}\\
-               \cpp{is\_invocable\_v<decay\_t<F>, stop\_token, fiber\_context&&>}
-\end{description}
-
-\effects
-\begin{description}
-    \item[---] Initializes \cpp{ssource}.
-    \item[---] Instantiates a \fiber representing a fiber suspended before
-              entry to \cpp{entry}.
-              \tsnote{\cpp{entry} is entered only when \anyresume is called.}
-    \item[---] The stack and any other necessary resources are created.
-\end{description}
-
-\postcond
-\begin{description}
-    \item[---] \cpp{ssource.stop\_possible()} returns \cpp{true}.
-    \item[---] \cpp{empty()} returns \cpp{false}.
-\end{description}
-
-\except
-\begin{description}
-    \item[---] Any exception resulting from failure to acquire necessary
-               system resources.
 \end{description}
 
 \mbrhdr{fiber\_context(fiber\_context\&\& other) noexcept}
@@ -204,8 +165,8 @@ If the fiber's \entryfn exits via an exception, \cpp{std::terminate} is called.
 \end{description}
 
 \tsnote{If a \fiber instance to be destroyed is not yet empty, an application
-must call \reqstop, or otherwise convey to the suspended fiber the need to
-terminate voluntarily.}
+must call \reqstop on the \source returned by \factory, or otherwise convey to
+the suspended fiber the need to terminate voluntarily.}
 
 \mbrhdr{fiber\_context\& operator=(fiber\_context\&\& other) noexcept}
 
@@ -252,9 +213,10 @@ terminate voluntarily.}
                Let \cpp{returned} be the \fiber instance returned by \cpp{fn}.
                \tsnote{\cpp{returned} may or may not be the same as \cpp{caller}.}
                \tsnote{\cpp{returned} may be empty.}
-    \item[---] If the fiber represented by \cpp{*this} has not previously been
+    \item[---] Let \cpp{source} be the \source returned by \factory.
+               If the fiber represented by \cpp{*this} has not previously been
                entered, passes \cpp{returned} to its \entryfn: executes\\
-               \cpp{invoke(std::forward<F>(entry), get\_stop\_token(), std::move(returned))}\\
+               \cpp{invoke(std::forward<F>(entry), source.get\_token(), std::move(returned))}\\
                if that expression is well-formed, otherwise\\
                \cpp{invoke(std::forward<F>(entry), std::move(returned))}
     \item[---] Otherwise, the fiber represented by \cpp{*this} previously
@@ -311,7 +273,7 @@ fiber has terminated (returned from \entryfn).}
 
 \tsnote{\anyresume empties the instance on which it is called. In order to
 express the state change explicitly, these methods are rvalue-reference
-qualified. For this reason, no non-empty \fiber instance ever represents the
+qualified. For this reason, no \fiber instance ever represents the
 currently-running fiber.}
 
 \mbrhdr{fiber\_context resume() \&\&}
@@ -319,18 +281,6 @@ currently-running fiber.}
 \effects
 Equivalent to:\\
 \cpp{resume\_with([](fiber\_context&& caller)\{ return std::move(caller); \})}
-
-\mbrhdr{[[nodiscard]] stop\_source get\_stop\_source() noexcept}
-
-\effects Equivalent to: \cpp{return ssource;}
-
-\mbrhdr{[[nodiscard]] stop\_token get\_stop\_token() const noexcept}
-
-\effects Equivalent to: \cpp{return ssource.get\_token();}
-
-\mbrhdr{bool request\_stop() noexcept;}
-
-\effects Equivalent to: \cpp{return ssource.request\_stop()}
 
 \mbrhdr{bool can\_resume() noexcept}
 
@@ -374,6 +324,44 @@ stack operations are effectively read-only.}
 \effects
 \begin{description}
     \item[---] Exchanges the state of \cpp{*this} with \cpp{other}.
+\end{description}
+
+\mbrhdr{template <typename F>
+        std::pair<fiber\_context, stop\_source> make\_fiber\_context(F\&\& entry)}
+
+\mandates
+\begin{description}
+    \item[---] \cpp{is\_invocable\_v<decay\_t<F>, fiber\_context&&> ||}\\
+               \cpp{is\_invocable\_v<decay\_t<F>, stop\_token, fiber\_context&&>}
+\end{description}
+
+\effects
+\begin{description}
+    \item[---] Initializes shared state for a \source.
+    \item[---] Instantiates a \fiber representing a fiber suspended before
+              entry to \cpp{entry}.
+              \tsnote{\cpp{entry} is entered only when \anyresume is called.}
+    \item[---] The stack and any other necessary resources are created.
+\end{description}
+
+\returns
+\begin{description}
+    \item[---] \cpp{std::pair} whose \cpp{first} is the \fiber representing
+               the new suspended fiber, and whose \cpp{second} is a \source
+               referencing the new shared state.
+    \item[---] The returned \cpp{second.stop\_possible()}
+               returns \cpp{is\_invocable\_v<decay\_t<F>, stop\_token, fiber\_context&&>}.
+\end{description}
+
+\postcond
+\begin{description}
+    \item[---] \cpp{empty()} returns \cpp{false}.
+\end{description}
+
+\except
+\begin{description}
+    \item[---] Any exception resulting from failure to acquire necessary
+               system resources.
 \end{description}
 
 %% \rSec3[fiber-context.unwinding]{Function unwind\_fiber()}

--- a/code/fiber.cpp
+++ b/code/fiber.cpp
@@ -5,10 +5,6 @@ inline namespace concurrency_v2 {
 class fiber_context {
 public:
     fiber_context() noexcept;
-
-    template<typename F>
-    explicit fiber_context(F&& entry);
-
     ~fiber_context();
 
     fiber_context(fiber_context&& other) noexcept;
@@ -20,20 +16,15 @@ public:
     template<typename Fn>
     fiber_context resume_with(Fn&& fn) &&;
 
-    // stop token handling
-    [[nodiscard]] stop_source get_stop_source() noexcept;
-    [[nodiscard]] stop_token get_stop_token() const noexcept;
-    bool request_stop() noexcept;
-
     bool can_resume() noexcept;
 
     explicit operator bool() const noexcept;
     bool empty() const noexcept;
     void swap(fiber_context& other) noexcept;
-
-private:
-    stop_source ssource;            // exposition only
 };
+
+template <typename Fn>
+std::pair<fiber_context, stop_source> make_fiber_context(Fn&& f);
 
 } // namespace concurrency_v2
 } // namespace experimental

--- a/code/initial_resume_with.cpp
+++ b/code/initial_resume_with.cpp
@@ -1,6 +1,6 @@
 fiber_context topfunc(fiber_context&& prev);
 fiber_context injected(fiber_context&& prev);
 
-fiber_context f(topfunc);
+fiber_context f{ make_fiber_context(topfunc).first };
 // topfunc() has not yet been entered
 std::move(f).resume_with(injected);

--- a/code/launch.cpp
+++ b/code/launch.cpp
@@ -24,7 +24,7 @@ private:
 // resuming the fiber that called ~autocancel().
 template <typename Fn>
 auto launch(Fn&& entry_function) {
-    return autocancel{std::fiber_context(
+    return autocancel{
         // entry-function passed to fiber_context constructor binds
         // entry_function, calls it within try/catch, catches
         // unwind_exception, extracts its shared_ptr<fiber_context>,
@@ -43,5 +43,5 @@ auto launch(Fn&& entry_function) {
         [](std::fiber_context&& previous)->std::fiber_context {
             throw unwind_exception{std::move(previous)};
             return {};
-        })};
+        }};
 }

--- a/code/ontop.cpp
+++ b/code/ontop.cpp
@@ -1,5 +1,5 @@
 int data = 0;
-fiber_context f{[&data](fiber_context&& m){
+fiber_context f{make_fiber_context([&data](fiber_context&& m){
     std::cout << "f1: entered first time: " << data  << std::endl;
     data+=1;
     m=std::move(m).resume();
@@ -8,7 +8,7 @@ fiber_context f{[&data](fiber_context&& m){
     m=std::move(m).resume();
     std::cout << "f1: entered third time: " << data << std::endl;
     return std::move(m);
-}};
+}).first};
 f=std::move(f).resume();
 std::cout << "f1: returned first time: " << data << std::endl;
 data+=1;

--- a/code/passing_lambda.cpp
+++ b/code/passing_lambda.cpp
@@ -1,10 +1,10 @@
 int i=1;
-std::fiber_context lambda{[&i](fiber_context&& caller){
+std::fiber_context lambda{make_fiber_context([&i](fiber_context&& caller){
     std::cout << "inside lambda,i==" << i << std::endl;
     i+=1;
     caller=std::move(caller).resume();
     return std::move(caller);
-}};
+}).first};
 lambda=std::move(lambda).resume();
 std::cout << "i==" << i << std::endl;
 lambda=std::move(lambda).resume();

--- a/code/return_from_resume_inplace.cpp
+++ b/code/return_from_resume_inplace.cpp
@@ -1,29 +1,29 @@
 int main(){
     fiber_context m,f1,f2,f3;
-    f3=fiber_context{[&](fiber_context&& f)->fiber_context{
+    f3=make_fiber_context([&](fiber_context&& f)->fiber_context{
         f2=std::move(f);
         for(;;){
             std::cout << "f3 ";
             std::move(f1).resume();
         }
         return {};
-    }};
-    f2=fiber_context{[&](fiber_context&& f)->fiber_context{
+    }).first;
+    f2=make_fiber_context([&](fiber_context&& f)->fiber_context{
         f1=std::move(f);
         for(;;){
             std::cout << "f2 ";
             std::move(f3).resume();
         }
         return {};
-    }};
-    f1=fiber_context{[&](fiber_context&& f)->fiber_context{
+    }).first;
+    f1=make_fiber_context([&](fiber_context&& f)->fiber_context{
         m=std::move(f);
         for(;;){
             std::cout << "f1 ";
             std::move(f2).resume();
         }
         return {};
-    }};
+    }).first;
     std::move(f1).resume();
     return 0;
 }

--- a/code/return_from_resume_invalid.cpp
+++ b/code/return_from_resume_invalid.cpp
@@ -1,29 +1,29 @@
 int main(){
     fiber_context m,f1,f2,f3;
-    f3=fiber_context{[&](fiber_context&& f)->fiber_context{
+    f3=make_fiber_context([&](fiber_context&& f)->fiber_context{
         f2=std::move(f);
         for(;;){
             std::cout << "f3 ";
             f2=std::move(f1).resume();
         }
         return {};
-    }};
-    f2=fiber_context{[&](fiber_context&& f)->fiber_context{
+    }).first;
+    f2=make_fiber_context([&](fiber_context&& f)->fiber_context{
         f1=std::move(f);
         for(;;){
             std::cout << "f2 ";
             f1=std::move(f3).resume();
         }
         return {};
-    }};
-    f1=fiber_context{[&](fiber_context&& f)->fiber_context{
+    }).first;
+    f1=make_fiber_context([&](fiber_context&& f)->fiber_context{
         m=std::move(f);
         for(;;){
             std::cout << "f1 ";
             f3=std::move(f2).resume();
         }
         return {};
-    }};
+    }).first;
     std::move(f1).resume();
     return 0;
 }

--- a/code/return_to_main.cpp
+++ b/code/return_to_main.cpp
@@ -1,8 +1,8 @@
 int main() {
-    fiber_context f{[]{
+    fiber_context f{make_fiber_context([]{
         ...
         // switch to `main()` only by returning
-    }};
+    }).first};
     f.resume(); // resume `f`
     return 0;
 }

--- a/code/static_current.cpp
+++ b/code/static_current.cpp
@@ -1,7 +1,7 @@
 int main(){
     int a;
     fiber_context m=fiber_context::current(); // get active fiber
-    fiber_context f{[&]{
+    fiber_context f{make_fiber_context([&]{
         a=0;
         int b=1;
         for(;;){
@@ -10,7 +10,7 @@ int main(){
             a=b;
             b=next;
         }
-    }};
+    }).first};
     for(int j=0; j<10; ++j) {
         f=f.resume(); // resume `f`
         std::cout << a << " ";

--- a/code/suspender.cpp
+++ b/code/suspender.cpp
@@ -1,8 +1,8 @@
-fiber_context f([](fiber_context&& caller){
+fiber_context f(make_fiber_context([](fiber_context&& caller){
     // ...
     std::move(caller).resume();
     // ...
-});
+}).first);
 
 fiber_context fn(fiber_context&&);
 

--- a/code/symmetric_op.cpp
+++ b/code/symmetric_op.cpp
@@ -1,15 +1,15 @@
 fiber_context* pf1;
-fiber_context f4{[&pf1]{
+fiber_context f4{make_fiber_context([&pf1]{
     pf1->resume();
-}};
-fiber_context f3{[&f4]{
+}).first};
+fiber_context f3{make_fiber_context([&f4]{
     f4.resume();
-}};
-fiber_context f2{[&f3]{
+}).first};
+fiber_context f2{make_fiber_context([&f3]{
     f3.resume();
-}};
-fiber_context f1{[&f2]{
+}).first};
+fiber_context f1{make_fiber_context([&f2]{
     f2.resume();
-}};
+}).first};
 pf1=&f1;
 f1.resume();

--- a/code/synopsis.cpp
+++ b/code/synopsis.cpp
@@ -8,6 +8,9 @@ inline namespace concurrency_v2 {
 
 class fiber_context;
 
+template <typename F>
+std::pair<fiber_context, stop_source> make_fiber_context(F&& entry);
+
 } // namespace concurrency_v2
 } // namespace experimental
 } // namespace std

--- a/code/synthesized_foo.cpp
+++ b/code/synthesized_foo.cpp
@@ -1,9 +1,9 @@
 void foo(){
-    fiber_context f{[](fiber_context&& m){
+    fiber_context f{make_fiber_context([](fiber_context&& m){
         m=std::move(m).resume(); // switch to `foo()`
         m=std::move(m).resume(); // switch to `foo()`
         ...
-    }};
+    }).first};
     f=std::move(f).resume(); // start `f`
     f=std::move(f).resume(); // resume `f`
     ...

--- a/code/synthesized_main.cpp
+++ b/code/synthesized_main.cpp
@@ -1,8 +1,8 @@
 int main(){
-    fiber_context f{[](fiber_context&& m){
+    fiber_context f{make_fiber_context([](fiber_context&& m){
         m=std::move(m).resume(); // switch to `main()`
         ...
-    }};
+    }).first};
     f=std::move(f).resume(); // resume `f`
     ...
     return 0;

--- a/code/terminating_fiber.cpp
+++ b/code/terminating_fiber.cpp
@@ -1,7 +1,7 @@
 int main(){
-    fiber_context f{[](fiber_context&& m){
+    fiber_context f{make_fiber_context([](fiber_context&& m){
         return std::move(m); // resume `main()` by returning `m`
-    }};
+    }).first};
     f = std::move(f).resume(); // resume `f`
     assert(f.empty());
     return 0;

--- a/code/terminating_fiber_complex.cpp
+++ b/code/terminating_fiber_complex.cpp
@@ -1,15 +1,15 @@
 int main(){
     fiber_context m;
-    fiber_context f1{[&](fiber_context&& f){
+    fiber_context f1{make_fiber_context([&](fiber_context&& f){
         std::cout << "f1: entered first time" << std::endl;
         assert(!f);
         return std::move(m); // resume (main-)fiber that has started `f2`
-    }};
-    fiber_context f2{[&](fiber_context&& f){
+    }).first};
+    fiber_context f2{make_fiber_context([&](fiber_context&& f){
         std::cout << "f2: entered first time" << std::endl;
         m=std::move(f); // preserve `f` (== suspended main())
         return std::move(f1);
-    }};
+    }).first};
     std::move(f2).resume();
     std::cout << "main: done" << std::endl;
     return 0;

--- a/commands.tex
+++ b/commands.tex
@@ -71,6 +71,7 @@
 \newcommand{\dtor}{\cpp{\~fiber\_context()}}
 \newcommand{\main}{\cpp{main()}}
 \newcommand{\fiber}{\cpp{std::fiber\_context}}
+\newcommand{\factory}{\cpp{std::make\_fiber\_context()}}
 \newcommand{\op}{\cpp{operator()()}}
 \newcommand{\opbool}{\cpp{operator bool()}}
 \newcommand{\resume}{\cpp{resume()}}
@@ -87,6 +88,7 @@
 \newcommand{\cancel}{\cpp{cancel()}}
 \newcommand{\xtcancel}{\cpp{cancel\_from\_any\_thread()}}
 \newcommand{\anycancel}{\cancel}
+\newcommand{\source}{\cpp{stop\_source}}
 \newcommand{\getsource}{\cpp{get\_stop\_source()}}
 \newcommand{\gettoken}{\cpp{get\_stop\_token()}}
 \newcommand{\reqstop}{\cpp{request\_stop()}}

--- a/for_examples.tex
+++ b/for_examples.tex
@@ -1,11 +1,11 @@
 \newpage
 \abschnitt{Appendix A: support code for examples}\label{launch}\label{appendixa}
 
-Destroying a non-empty \fiber instance invokes Undefined Behaviour -- you must
-first call \reqstop (see \nameref{termination}). To simplify code examples in
+Destroying a non-empty \fiber instance invokes Undefined Behaviour
+(see \nameref{termination}). To simplify code examples in
 this paper, we introduce an \cpp{autocancel} wrapper class that tracks the
 sequence of \fiber instances representing a particular fiber. When
 an \cpp{autocancel} instance is destroyed, it calls \reqstop on the
-stored \fiber and loops until the fiber voluntarily terminates.
+captured \source and loops until the fiber voluntarily terminates.
 
 \cppf{autocancel}

--- a/history.tex
+++ b/history.tex
@@ -1,5 +1,26 @@
 \abschnitt{Revision History}\label{history}
-This document supersedes P0876R10.
+This document supersedes P0876R11.
+
+\uabschnitt{Changes since P0876R11}
+
+\begin{itemize}
+    \item Removed \cpp{get\_stop\_source()}, \cpp{get\_stop\_token()}, \cpp{request\_stop()}
+          and exposition-only \cpp{ssource} members.
+    \item Replaced with \cpp{make\_fiber\_context()} factory function.
+\end{itemize}
+
+Bundling a \cpp{stop\_source} into \fiber presented implementability concerns.
+Although each fiber (specifically, its function call stack) is itself a
+persistent entity, the \cpp{fiber\_context} representing that fiber is not: a
+new \cpp{fiber\_context} object is synthesized on every suspension. This
+presents a problem: how does the code that suspends a fiber find its
+associated \cpp{stop\_source} shared state?
+
+This problem is addressed by removing the exposition-only \cpp{stop\_source}
+and its accessors from \cpp{fiber\_context}. The new factory function
+instantiates the \cpp{stop\_source} shared state and returns
+the \cpp{stop\_source} along with the new \cpp{fiber\_context}. Keeping track
+of the \cpp{stop\_source} is the caller's responsibility.
 
 \uabschnitt{Changes since P0876R10}
 

--- a/references.tex
+++ b/references.tex
@@ -97,6 +97,10 @@
         \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p0876r10.pdf}
         {P0876R10: fibers without scheduler}
 
+    \bibitem{P0876R11}
+        \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0876r11.pdf}
+        {P0876R11: fibers without scheduler}
+
     \bibitem{P1677R2}
         \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1677r2.pdf}
         {P1677R2: Cancellation is serendipitous-success}

--- a/termination.tex
+++ b/termination.tex
@@ -48,7 +48,7 @@ am suspending; please resume me later.''
 \emph{Returning} a particular \fiber means: ``Please switch to the indicated
 fiber; and by the way, I am done.''
 
-The \getsource\xspace / \gettoken\xspace / \reqstop mechanism provides a way for
+The \source returned by \factory provides a way for
 consuming code to attempt to communicate to a suspended fiber the desire that
 it should terminate. The intention is that the program may call \reqstop
 before destroying a \fiber instance that might not be empty, or is known not
@@ -64,8 +64,9 @@ return.
 One tactic would be to call \reqstop, then loop over \anyresume calls until
 the returned \fiber is \cpp{empty()}. However, that information is ambiguous.
 
-Suppose we have a \fiber instance \cpp{f1} representing suspended fiber F. The
-running fiber M calls \cpp{f1.request\_stop()}, then \cpp{f1.resume()}, which
+Suppose we have a \fiber instance \cpp{f1} representing suspended fiber F,
+with associated \source\xspace \cpp{ssource}. The
+running fiber M calls \cpp{ssource.request\_stop()}, then \cpp{f1.resume()}, which
 returns another \fiber instance \cpp{f2}.
 
 \cpp{f2} has various possible values.


### PR DESCRIPTION
This version removes the exposition-only std::stop_source from fiber_context, along with its accessors get_stop_source(), get_stop_token() and request_stop(). Instead we introduce the make_fiber_context() factory function, which returns std::pair<fiber_context, stop_source>. This eliminates the requirement to rediscover the stop_source shared state every time we synthesize a fiber_context instance representing a newly-suspended fiber.

To streamline the API, we remove the fiber_context constructor accepting entry-function, which is somewhat redundant with make_fiber_context(). In this revision, make_fiber_context() is the only way to launch a new fiber.