### PR TITLE
Accept span<byte, N> instead of void* as explicit stack area.

### DIFF
--- a/api.tex
+++ b/api.tex
@@ -177,7 +177,7 @@ If the fiber's \entryfn exits via an exception, \cpp{std::terminate} is called.
                system resources.
 \end{description}
 
-\mbrhdr{template<typename F> explicit fiber\_context(F\&\& entry, void* stack)}
+\mbrhdr{template<typename F, size\_t N> explicit fiber\_context(F\&\& entry, span<byte, N> stack)}
 
 \mandates
 \begin{description}

--- a/code/fiber.cpp
+++ b/code/fiber.cpp
@@ -8,8 +8,8 @@ public:
     template<typename F>
     explicit fiber_context(F&& entry);
 
-    template<typename F>
-    explicit fiber_context(F&& entry, void* stack);
+    template<typename F, size_t N>
+    explicit fiber_context(F&& entry, span<byte, N> stack);
 
     ~fiber_context();
 


### PR DESCRIPTION
Even though the fiber_context library has no checks to constrain the stack to the specified size, it's still important to specify both ends of the passed area, since portable code can't know in which direction the running CPU will consume the stack. If fiber_context() accepted only a void* pointer, which end of the stack block should the caller pass?