### PR TITLE
Addressing more feedback from Robert Leahy.

### DIFF
--- a/P0876R13.tex
+++ b/P0876R13.tex
@@ -60,7 +60,7 @@
 \small
 \begin{tabbing}
     Document number: \= P0876R13\\
-    Date:            \> 2023-02-14\\
+    Date:            \> 2023-02-18\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> LEWG\\

--- a/api.tex
+++ b/api.tex
@@ -9,9 +9,6 @@
 
 \rSec3[fiber-context.general]{General}
 
-The extensions proposed here support creation and activation of cooperative
-user-mode threads, here called \emph{fibers}.
-
 A fiber is a thread of execution ([intro.multithread.general]) with
 weakly parallel forward progress guarantees ([intro.progress] paragraph 11).
 
@@ -43,6 +40,10 @@ current, in a manner appropriate to the existing implementation of function call
 A \fiber instance may be \emph{empty} or \emph{non-empty}. A
 default-constructed \fiber is empty. A moved-from \fiber is empty. A \fiber
 representing a suspended fiber is non-empty.
+
+When the running fiber returns a \fiber from its \entryfn, thus resuming the
+designated fiber, the synthesized \fiber passed into the resumed fiber is
+empty.
 
 \rSec3[fiber-context.implicit]{Explicit Fiber vs. Implicit Fiber}
 
@@ -81,8 +82,7 @@ The synthesized \fiber instance received in either of those ways might
 represent either an explicit fiber or an implicit fiber.
 
 An explicit fiber terminates by returning from its \entryfn. If the \entryfn
-returns a non-empty \fiber instance, the fiber represented by that \fiber
-instance is resumed.
+returns a non-empty \fiber instance, \thefiber{that \fiber instance} is resumed.
 
 %% \rSec3[fiber-context.toplevel]{Implicit Top-Level Function}
 
@@ -96,10 +96,10 @@ If the fiber's \entryfn exits via an exception, \cpp{std::terminate} is called.
 
 \rSec3[fiber-context.currexc]{fiber\_context, uncaught\_exceptions and current\_exception}
 
-\cpp{uncaught\_exceptions} returns the total number of uncaught exceptions on
-any fiber within the current thread.
+The function \cpp{std::uncaught\_exceptions} ([uncaught.exceptions]) returns
+the number of uncaught exceptions in the calling fiber.
 
-\cpp{current\_exception} returns the exception currently being handled on the
+\cpp{std::current\_exception} ([propagation]) returns the exception currently being handled on the
 calling fiber.
 
 %% Returning a \fiber instance from the explicit fiber's \entryfn is equivalent
@@ -132,14 +132,19 @@ calling fiber.
 %%     function above \main, the process is terminated.
 %% \end{itemize}
 
+%--------------------------------- synopsis ----------------------------------
 \rSec3[fiber-context.synopsis]{Header <fiber\_context> synopsis}
 
 \cppf{synopsis}
 
+%--------------------------------- class def ---------------------------------
 \rSec3[fiber-context.class]{Class fiber\_context}
 
 \cppf{fiber}
 
+\newcommand{\state}{\cpp{state}}
+
+%------------------------------- nullary ctor --------------------------------
 \mbrhdr{fiber\_context() noexcept}\label{constructor}
 
 \effects
@@ -149,14 +154,15 @@ calling fiber.
 
 \postcond
 \begin{description}
-    \item[---] \cpp{empty()} returns \cpp{true}.
+    \item[---] \emptyfn returns \true.
 \end{description}
 
+%---------------------------- implicit stack ctor ----------------------------
 \mbrhdr{template<typename F> explicit fiber\_context(F\&\& entry)}
 
 \constraints
 \begin{description}
-    \item[---] \cpp{remove\_cvref\_t<F>} is not the same type as \cpp{fiber\_context}.
+    \item[---] \cpp{remove\_cvref\_t<F>} is not the same type as \fiber.
 \end{description}
 
 \mandates
@@ -177,7 +183,7 @@ calling fiber.
 
 \postcond
 \begin{description}
-    \item[---] \cpp{empty()} returns \cpp{false}.
+    \item[---] \emptyfn returns \false.
 \end{description}
 
 \except
@@ -187,15 +193,7 @@ calling fiber.
     \item[---] Any exception thrown by \cpp{entry}'s copy constructor.
 \end{description}
 
-\remarks
-\begin{description}
-    \item[---] On return from \cpp{Entry}:
-        \begin{itemize}
-            \item destroys \cpp{Entry}
-            \item destroys the stack.
-        \end{itemize}
-\end{description}
-
+%---------------------------- explicit stack ctor ----------------------------
 \mbrhdr{template<typename F, typename D> explicit fiber\_context(F\&\& entry, span<byte> stack, D\&\& deleter)}
 
 \mandates
@@ -231,7 +229,7 @@ calling fiber.
 
 \postcond
 \begin{description}
-    \item[---] \cpp{empty()} returns \cpp{false}.
+    \item[---] \emptyfn returns \false.
 \end{description}
 
 \except
@@ -248,57 +246,49 @@ calling fiber.
 
 \remarks
 \begin{description}
-    \item[---] On return from \cpp{Entry}:
-        \begin{itemize}
-            \item evaluates \cpp{invoke(Deleter, Stack)} on the fiber
-                  represented by the \cpp{fiber\_context} returned by \cpp{Entry}
-            \item destroys \cpp{Entry}
-            \item destroys \cpp{Deleter}.
-        \end{itemize}
-    \item[---] If the function call stack depth exceeds the size
-               of \cpp{stack}, Undefined Behaviour results. This condition
-               does \emph{not} throw a well-defined exception.
+    \item[---] If at any time during the life of the newly created fiber the
+          function call stack depth exceeds the size of \cpp{stack}, Undefined
+          Behaviour results.
 \end{description}
 
+%--------------------------------- move ctor ---------------------------------
 \mbrhdr{fiber\_context(fiber\_context\&\& other) noexcept}
 
-\effects
 \begin{description}
-    \item[---] As-if \cpp{this->state = move(other.state);}
+    \item[---] Equivalent to \cpp{this->state = move(other.state);}
 \end{description}
 
+%----------------------------------- dtor ------------------------------------
 \mbrhdr{\cpp{\~fiber\_context()}}
 
 \effects
 \begin{description}
-    \item[---] destroys a \fiber instance.
-\end{description}
-
-\effects
-\begin{description}
-    \item[---] If \cpp{empty()} returns \cpp{false}, evaluates \cpp{invoke(terminate)}.
+    \item[---] Destroys a \fiber instance.
+    \item[---] If \emptyfn returns \false, invokes \cpp{terminate} ([except.terminate]).
 \end{description}
 
 \tsnote{If a \fiber instance to be destroyed is not yet empty, an application
 must convey to the suspended fiber the need to terminate voluntarily.}
 
+%------------------------------ move assignment ------------------------------
 \mbrhdr{fiber\_context\& operator=(fiber\_context\&\& other) noexcept}
 
 \precond
 \begin{description}
-    \item[---] \cpp{empty()} returns \cpp{true}.
+    \item[---] \emptyfn returns \true.
 \end{description}
 
 \effects
 \begin{description}
-    \item[---] As-if \cpp{this->state = move(other.state);}
+    \item[---] Equivalent to \cpp{this->state = move(other.state);}
 \end{description}
 
 \returns
 \begin{description}
-    \item[---] \cpp{*this}
+    \item[---] \this
 \end{description}
 
+%-------------------------------- resume_with --------------------------------
 \mbrhdr{template<typename Fn> fiber\_context resume\_with(Fn\&\& fn) \&\&}
 
 \mandates
@@ -308,18 +298,18 @@ must convey to the suspended fiber the need to terminate voluntarily.}
 
 \precond
 \begin{description}
-    \item[---] \cpp{empty()} returns \cpp{false}
-    \item[---] the fiber represented by \cpp{*this} has no owning thread,
-               or \currthread is the owning thread
+    \item[---] \canresume returns \true
 \end{description}
+
+\newcommand{\continuation}{\cpp{continuation}}
 
 \effects
 \begin{description}
     \item[---] Saves the execution context of the calling fiber in a manner
                appropriate to the host ABI.
     \item[---] Suspends the calling fiber.
-    \item[---] Let \cpp{target} be the fiber represented by \cpp{state}.
-    \item[---] Resets \cpp{state} so that \cpp{empty()} returns \cpp{true}.
+    \item[---] Let \cpp{target} be \thefiber{\state}.
+    \item[---] Resets \state so that \emptyfn returns \true.
     \item[---] Resumes \cpp{target}.
     \item[---] Restores the execution context of \cpp{target}.
     \item[---] Let \cpp{caller} be a synthesized \fiber instance representing
@@ -330,8 +320,20 @@ must convey to the suspended fiber the need to terminate voluntarily.}
                \tsnote{\cpp{returned} may or may not be the same as \cpp{caller}.}
                \tsnote{\cpp{returned} may be empty.}
     \item[---] If \cpp{target} has not previously been
-               entered, passes \cpp{returned} to its \entryfn: executes\\
-               \cpp{invoke(Entry, std::move(returned))}
+               entered, passes \cpp{returned} to its \entryfn. Let \continuation
+               be the result of executing
+               \cpp{invoke\_r<fiber\_context>(Entry, std::move(returned))}. On return:
+        \begin{itemize}
+            \item restores the execution context of \continuation
+            \item destroys \cpp{Entry}
+            \item if \cpp{target} has an associated \cpp{Stack} and \cpp{Deleter}:
+                \begin{itemize}
+                    \item executes \cpp{invoke(Deleter, Stack)}
+                    \item destroys \cpp{Deleter}
+                \end{itemize}
+            \item otherwise reclaims the implementation-provided stack
+            \item resumes \continuation as if by \cpp{continuation.resume()}.
+        \end{itemize}
     \item[---] Otherwise, \cpp{target} previously
                suspended itself by calling one of \anyresume.
                Returns \cpp{returned} from that resume function.
@@ -359,29 +361,34 @@ must convey to the suspended fiber the need to terminate voluntarily.}
 %             \unwindex when, while suspended, the \fiber instance representing
 %             the suspended fiber is destroyed
     \item[---] Nothing before suspending the calling fiber and
-               ensuring \cpp{empty()} returns \cpp{true}.
-    \item[---] On resuming:
+               ensuring \emptyfn returns \true.
+    \item[---] On being resumed:
     \begin{itemize}
-        \item If the previous fiber resumed this one by returning a \fiber,
-              nothing.
+        \item If the previous fiber resumed this one by returning a \fiber:
+            \begin{itemize}
+                \item Any exception thrown as a result of destroying the
+                      previous fiber's associated \cpp{Entry}.
+                \item Any exception thrown by the previous fiber's
+                      associated \cpp{Deleter}.
+                \item Any exception thrown as a result of destroying the
+                      previous fiber's associated \cpp{Deleter}.
+            \end{itemize}
         \item If the previous fiber resumed this one by calling \someresume,
               nothing.
         \item If the previous fiber resumed this one by calling \anyresumewith:
         \begin{itemize}
-            \item If the \cpp{fn} passed by the previous fiber
-                  to \anyresumewith returned \fiber, nothing.
-            \item If the \cpp{fn} passed by the previous fiber
-                  to \anyresumewith threw an exception, that exception.
+            \item Any exception thrown by the \cpp{fn} passed by the previous
+                  fiber to \anyresumewith.
         \end{itemize}
     \end{itemize}
 \end{description}
 
 \postcond
 \begin{description}
-    \item[---] \cpp{empty()} returns \cpp{true}
+    \item[---] \emptyfn returns \true
 \end{description}
 
-\tsnote{The returned \cpp{fiber\_context} indicates via \cpp{empty()} whether the previous active
+\tsnote{The returned \fiber indicates via \emptyfn whether the previous active
 fiber has terminated (returned from \entryfn).}
 
 \tsnote{\anyresume empties the instance on which it is called. In order to
@@ -389,21 +396,24 @@ express the state change explicitly, these methods are rvalue-reference
 qualified. For this reason, no \fiber instance ever represents the
 currently-running fiber.}
 
+%---------------------------------- resume -----------------------------------
 \mbrhdr{fiber\_context resume() \&\&}
 
-\effects
-As-if:\\
+Equivalent to:\\
 \cpp{resume\_with([](fiber\_context&& caller)\{ return std::move(caller); \})}
 
+%-------------------------------- can_resume ---------------------------------
 \mbrhdr{bool can\_resume() noexcept}
 
 \returns
 \begin{description}
-    \item[---] \cpp{false} if \cpp{empty()} returns \cpp{true}, or if \currthread is not
-        \ownthread.
+    \item[---] \false if \emptyfn returns \true
+    \item[---] \true if \thisfiber has no owning thread
+    \item[---] \true if \currthread is \ownthread
+    \item[---] \false otherwise.
 \end{description}
 
-\tsnote{When \canresume returns \cpp{true}, the \fiber instance may be resumed
+\tsnote{When \canresume returns \true, the \fiber instance may be resumed
 by \anyresume.}
 
 \remarks
@@ -414,28 +424,30 @@ by \anyresume.}
 \EnterBlock{Editorial note} \canresume is intentionally not
 marked \cpp{const}. \ExitBlock{editorial note}
 
+%----------------------------------- empty -----------------------------------
 \mbrhdr{bool empty() const noexcept}
 
 \returns
 \begin{description}
-    \item[---] \cpp{false} if \cpp{state} represents a fiber of
-               execution, \cpp{true} otherwise.
+    \item[---] \false if \state represents a fiber of
+               execution, \true otherwise.
 \end{description}
 
 \tsnote{Regardless of the number of \fiber declarations, exactly one
 \fiber instance represents each suspended fiber.}
 
+%------------------------------- operator bool -------------------------------
 \mbrhdr{explicit operator bool() const noexcept}
 
 \begin{description}
-    \item[---] As-if \cpp{(\! empty())}
+    \item[---] Equivalent to \cpp{(\! empty())}
 \end{description}
 
+%----------------------------------- swap ------------------------------------
 \mbrhdr{void swap(fiber\_context\& other) noexcept}
 
-\effects
 \begin{description}
-    \item[---] As-if \cpp{swap(this->state, other.state);}
+    \item[---] Equivalent to \cpp{swap(this->state, other.state);}
 \end{description}
 
 %% \rSec3[fiber-context.unwinding]{Function unwind\_fiber()}

--- a/commands.tex
+++ b/commands.tex
@@ -68,9 +68,12 @@
         stringstyle=\ttfamily\color{magenta}
 ] {code/#1.cpp}}
 
+\newcommand{\true}{\cpp{true}}
+\newcommand{\false}{\cpp{false}}
 \newcommand{\dtor}{\cpp{\~fiber\_context()}}
 \newcommand{\main}{\cpp{main()}}
-\newcommand{\fiber}{\cpp{std::fiber\_context}}
+\newcommand{\stdfiber}{std::\fiber}
+\newcommand{\fiber}{\cpp{fiber\_context}}
 \newcommand{\op}{\cpp{operator()()}}
 \newcommand{\opbool}{\cpp{operator bool()}}
 \newcommand{\resume}{\cpp{resume()}}
@@ -87,6 +90,7 @@
 \newcommand{\cancel}{\cpp{cancel()}}
 \newcommand{\xtcancel}{\cpp{cancel\_from\_any\_thread()}}
 \newcommand{\anycancel}{\cancel}
+\newcommand{\emptyfn}{\cpp{empty()}}
 %% referenced in history.tex
 \newcommand{\source}{\cpp{stop\_source}}
 \newcommand{\getsource}{\cpp{get\_stop\_source()}}
@@ -98,7 +102,10 @@
 \newcommand{\thread}{\cpp{std::thread}}
 \newcommand{\Currthread}{The calling thread\xspace}
 \newcommand{\currthread}{the calling thread\xspace}
-\newcommand{\ownthread}{the owning thread of the fiber represented by \cpp{*this}}
+\newcommand{\ownthread}{the owning thread of \thisfiber}
+\newcommand{\thisfiber}{\thefiber{\this}}
+\newcommand{\thefiber}[1]{the fiber represented by #1}
+\newcommand{\this}{\cpp{*this}}
 \newcommand{\unwindex}{\cpp{std::unwind\_exception}}
 \newcommand{\unwindfib}{\cpp{std::unwind\_fiber()}}
 \newcommand{\uwforced}{\cpp{_Unwind_ForcedUnwind()}}

--- a/ecosystem.tex
+++ b/ecosystem.tex
@@ -21,10 +21,10 @@ facility will ensure support in every implementation of the C++ runtime,
 extending into the future.
 
 Given the lively ecosystem of open-source libraries, it's possible that
-standardizing \cpp{fiber\_context} could suffice. It is not essential that
+standardizing \fiber could suffice. It is not essential that
 WG21 must standardize additional higher-level libraries before the facility
 would become useful. The uptake of \emph{Boost.Context} illustrates that the
-community can make good use of \cpp{fiber\_context}.
+community can make good use of \fiber.
 
 However, the evolution of this proposal and the WG21 discussions thereof have
 surfaced a number of interesting adjacencies.
@@ -183,6 +183,6 @@ analyzers and other tools that inspect a running C++ program.
 
 Such tools need only be aware of \fiber. They would \emph{not} need to be
 further adapted to support higher-level libraries built on
-the \cpp{fiber\_context} facility.
+the \fiber facility.
 
 \newpage

--- a/history.tex
+++ b/history.tex
@@ -9,9 +9,9 @@ This document supersedes P0876R12.
           simply \cpp{span<byte>}; also accepted deleter function, which it
           must \emph{decay-copy}.
     \item Specified constructor exceptions.
-    \item Specified that destroying a non-empty \cpp{fiber\_context}
+    \item Specified that destroying a non-empty \fiber
           calls \cpp{terminate()}.
-    \item Clarified that when \resumewith is called, \cpp{empty()} becomes
+    \item Clarified that when \resumewith is called, \emptyfn becomes
           true immediately.
     \item Introduced exposition-only \cpp{fiber\_context::state} member to
           streamline wording.
@@ -25,20 +25,20 @@ This document supersedes P0876R12.
 \begin{itemize}
     \item Removed \getsource, \gettoken, \reqstop and
           exposition-only \cpp{ssource} members.
-    \item Added a \cpp{fiber\_context} constructor accepting a caller-provided
+    \item Added a \fiber constructor accepting a caller-provided
           uninitialized memory area for the new fiber's function call stack.
 \end{itemize}
 
 Bundling a \cpp{stop\_source} into \fiber presented implementability concerns.
 Although each fiber (specifically, its function call stack) is itself a
-persistent entity, the \cpp{fiber\_context} representing that fiber is not: a
-new \cpp{fiber\_context} object is synthesized on every suspension. This
+persistent entity, the \fiber representing that fiber is not: a
+new \fiber object is synthesized on every suspension. This
 presents a problem: how does the code that suspends a fiber find its
 associated \cpp{stop\_source} shared state?
 
 A consumer wishing to pass a \cpp{std::stop\_token} to a new fiber can itself
 instantiate \cpp{std::stop\_source}, obtain from it a \cpp{stop\_token} and
-bind that \cpp{stop\_token} in a lambda passed to the \cpp{fiber\_context}
+bind that \cpp{stop\_token} in a lambda passed to the \fiber
 constructor. Accordingly, the \fiber API need not explicitly support that.
 
 \uabschnitt{Changes since P0876R10}
@@ -108,7 +108,7 @@ a particular fiber earlier in the lifespan of the fiber, a struct serves.
 A more compelling reason to avoid constructing an explicit fiber with
 a \cancelfn is that no implicit fiber has any such \cancelfn\xspace -- and the
 consuming application cannot tell, a priori, whether a given \fiber instance
-represents an explicit or an implicit fiber. If \cpp{*this} represents an
+represents an explicit or an implicit fiber. If \this represents an
 implicit fiber, what should the proposed \cpp{cancel()} member function do?
 
 Passing a specific \cancelfn to \anyresumewith avoids that problem.
@@ -131,16 +131,16 @@ auditable).
 In Cologne 2019, SG1 took the position that:
 
 \begin{itemize}
-    \item The \cpp{fiber\_context} facility is not the only C++ feature that
+    \item The \fiber facility is not the only C++ feature that
           requires ``special'' unwinding (special function exit path).
     \item Such functionality should be decoupled from \fiber. It requires its
           own proposal that follows its own course through WG21 process.
     \item Depending on this (yet to be written) proposal would unduly delay
-          the \cpp{fiber\_context} facility.
-    \item For now, the \cpp{fiber\_context} facility should adopt a ``less is
+          the \fiber facility.
+    \item For now, the \fiber facility should adopt a ``less is
           more'' approach, removing promises about implicit unwinding, placing
           the burden on the consumer of the facility instead.
-    \item This leaves the way open for \cpp{fiber\_context} to integrate with
+    \item This leaves the way open for \fiber to integrate with
           a new, improved unwind facility when such becomes available.
 \end{itemize}
 
@@ -160,7 +160,7 @@ default engages the new, improved unwind facility.
     \item \cpp{std::unwind\_exception} removed.
     \item \cpp{fiber\_context::can\_resume\_from\_any\_thread()} renamed to
       \canxtresume.
-    \item \cpp{fiber\_context::valid()} renamed to \cpp{empty()} with inverted
+    \item \cpp{fiber\_context::valid()} renamed to \emptyfn with inverted
       sense.
     \item Material has been added concerning the top-level wrapper
       logic governing each fiber.

--- a/passing_data.tex
+++ b/passing_data.tex
@@ -21,7 +21,7 @@ Since the updated \cpp{caller} represents the fiber suspended by the call at
 line 10, control returns to \main.
 
 However, since fiber \cpp{lambda} has now terminated, the updated \cpp{lambda}
-is empty. Its \opbool returns \cpp{false}.
+is empty. Its \opbool returns \false.
 
 \zs{Using lambda capture is the preferred way to transfer data between two
 fibers; global pointers or a calling wrapper (such as \cpp{std::bind}) are

--- a/resume_with.tex
+++ b/resume_with.tex
@@ -29,7 +29,7 @@ lambda. It is as if the \cpp{m.resume()} call at line 8 directly called the seco
 lambda.
 
 The function passed to \resumewith has almost the same range of possibilities as
-any function called on the fiber represented by \cpp{f}. Its special invocation
+any function called on \thefiber{\cpp{f}}. Its special invocation
 matters when control leaves it in either of two ways:
 
 \begin{enumerate}

--- a/solution_gp_ub.tex
+++ b/solution_gp_ub.tex
@@ -31,18 +31,18 @@ is transferred back to the lambda and instance \cpp{m} represents the suspended
 Function \cpp{foo()} is resumed at line 4 by executing \cpp{m.resume()} so that
 control returns at line 8 and so on ...
 
-Class \cpp{symmetric_coroutine<>::yield_type} from N3985\cite{N3985} is
+Class \cpp{symmetric\_coroutine<>::yield\_type} from N3985\cite{N3985} is
 \bfs{not} equivalent to the synthesized \fiber.
 
-\cpp{symmetric_coroutine<>::yield_type} does not represent the suspended context,
+\cpp{symmetric\_coroutine<>::yield\_type} does not represent the suspended context,
 instead it is a special representation of the same coroutine. Thus \main or
-the current thread's \entryfn can \bfs{not} be represented by \cpp{yield_type}
+the current thread's \entryfn can \bfs{not} be represented by \cpp{yield\_type}
 (see next section \nameref{representation}).
 
-Because \cpp{symmetric_coroutine<>::yield_type()} yields back to the starting
+Because \cpp{symmetric\_coroutine<>::yield\_type()} yields back to the starting
 point, i.e. invocation of\\
-\cpp{symmetric_coroutine<>::call_type::operator()()},
-both instances (\cpp{call_type} as well as \cpp{yield_type}) must be preserved.
+\cpp{symmetric\_coroutine<>::call\_type::operator()()},
+both instances (\cpp{call\_type} as well as \cpp{yield\_type}) must be preserved.
 Additionally the caller must be kept alive until the called coroutine terminates
 or UB happens at resumption.
 
@@ -84,7 +84,7 @@ internal global variables that point to \main is to explicitly return a non-empt
 \cppfl{terminating_fiber}
 
 In line 5 the fiber is started by invoking \resume on instance \cpp{f}. \main
-is suspended and an instance of type \cpp{fiber\_context} is synthesized and passed as
+is suspended and an instance of type \fiber is synthesized and passed as
 parameter \cpp{m} to the lambda at line 2. The fiber terminates by returning
 \cpp{m}. Control is transferred to \main (returning from \cpp{f.resume()} at
 line 5) while fiber \cpp{f} is destroyed.

--- a/termination.tex
+++ b/termination.tex
@@ -49,7 +49,7 @@ am suspending; please resume me later.''
 fiber; and by the way, I am done.''
 
 Cancellation of another fiber is not explicitly supported
-by \cpp{fiber\_context}. If it is important for consuming code to communicate
+by \fiber. If it is important for consuming code to communicate
 to a suspended fiber the desire that it should terminate, lambda binding may
 be used to pass some relevant object, e.g. a \cpp{stop\_token}.
 
@@ -59,7 +59,7 @@ request before it could possibly observe the change. Even then, the \entryfn
 might not immediately return.
 
 One tactic would be to request termination, then loop over \anyresume calls until
-the returned \fiber is \cpp{empty()}. However, that information is ambiguous.
+the returned \fiber is \emptyfn. However, that information is ambiguous.
 
 Suppose we have a \fiber instance \cpp{f1} representing suspended fiber F,
 with an application-specific termination request mechanism. The running fiber
@@ -93,7 +93,7 @@ above.
 
 %% The \emph{last} fiber on a particular thread has no non-empty \fiber to
 %% return. For this reason, returning an empty \fiber instance (\opbool
-%% returns \cpp{false}) terminates the calling thread. This is true whether or
+%% returns \false) terminates the calling thread. This is true whether or
 %% not the thread's default fiber (see \nameref{fiber-context.implicit}) has
 %% terminated.
 
@@ -157,7 +157,7 @@ above.
 %% As a consequence, \curex can not return a \cpp{std::exception\_ptr} pointing
 %% to a \foreignex.
 %% 
-%% In order to detect if stack unwinding is currently in progress \uncex returns \cpp{true} and\\
+%% In order to detect if stack unwinding is currently in progress \uncex returns \true and\\
 %% \uncexs counts the \foreignex.
 %% 
 %% The rationale for moving to an uncatchable exception is further explained in


### PR DESCRIPTION
Introduced a few more shorthand commands, pervasively replacing the wordy form with the shortcut.

Mentioned another reason for a fiber_context to be empty: the instance returned by a resume() call upon termination of the previous fiber.

Moved Deleter(Stack) call, and destruction of Entry and Deleter, to Effects of resume_with(). Added potential exceptions therefrom to resume_with().

Undefined Behaviour throws no dependable exception.

Borrowed terminate() call wording from existing Standard.

Simplified resume_with() Preconditions to can_resume().

Changed uncaught_exceptions to be fiber-local.