### PR TITLE
Qualify std::uncaught_exceptions and std::current_exception.

### DIFF
--- a/P0876R13.tex
+++ b/P0876R13.tex
@@ -60,7 +60,7 @@
 \small
 \begin{tabbing}
     Document number: \= P0876R13\\
-    Date:            \> 2023-02-18\\
+    Date:            \> 2023-02-21\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> LEWG\\

--- a/api.tex
+++ b/api.tex
@@ -1,16 +1,30 @@
 \newpage
+\abschnitt{API}\label{api}
+
+This wording is relative to N4928.\cite{Standard}
+
+\bfs{Modify} 14.4.8 \stdclause{except.handle} as indicated:
+
+The exception with the most recently activated handler \add{in the current
+thread of execution }that is still active is called the \emph{currently handled exception.}
+
+\bfs{Modify} 14.6.3.1 \stdclause{except.uncaught} as indicated:
+
+The function \cpp{std::uncaught\_exceptions}
+(\stdclause{uncaught.exceptions}) returns the number of uncaught exceptions
+in the current thread\add{ of execution}.
+
+\bfs{Insert} new final subclause in clause 33 \stdclause{thread} as indicated:
 
 \setcounter{section}{33}
 \setcounter{subsection}{10}
-
-\abschnitt{API}\label{api}
 
 \rSec2[fiber-context]{Cooperative User-Mode Threads}
 
 \rSec3[fiber-context.general]{General}
 
-A fiber is a thread of execution ([intro.multithread.general]) with
-weakly parallel forward progress guarantees ([intro.progress] paragraph 11).
+A fiber is a thread of execution (\stdclause{intro.multithread.general}) with
+weakly parallel forward progress guarantees (\stdclause{intro.progress} paragraph 11).
 
 The term ``user-mode'' means that control can be passed from one fiber to
 another without entering the operating-system kernel.
@@ -25,7 +39,7 @@ fiber.
 
 Suspending the running fiber in order to resume (or launch) another is
 called \emph{context switching}. This is an explicit variant of blocking with
-forward progress guarantee delegation ([intro.progress] paragraph 14).
+forward progress guarantee delegation (\stdclause{intro.progress} paragraph 14).
 
 Launching a fiber logically creates a new function call stack, which remains
 associated with that fiber throughout its lifetime. Calling functions on a
@@ -93,14 +107,6 @@ returns a non-empty \fiber instance, \thefiber{that \fiber instance} is resumed.
 %% is where unwinding stops.
 
 If the fiber's \entryfn exits via an exception, \cpp{std::terminate} is called.
-
-\rSec3[fiber-context.currexc]{fiber\_context, uncaught\_exceptions and current\_exception}
-
-The function \cpp{std::uncaught\_exceptions} ([uncaught.exceptions]) returns
-the number of uncaught exceptions in the calling fiber.
-
-\cpp{std::current\_exception} ([propagation]) returns the exception currently being handled on the
-calling fiber.
 
 %% Returning a \fiber instance from the explicit fiber's \entryfn is equivalent
 %% to returning control to the implicit top-level function.
@@ -173,10 +179,10 @@ calling fiber.
 
 \effects
 \begin{description}
-    \item[---] Let \cpp{Entry} be saved as-if by \emph{decay-copy}\cpp{(std::forward<F>(entry))}.
+    \item[---] Let \cpp{entry\_copy} be saved as-if by \emph{decay-copy}\cpp{(std::forward<F>(entry))}.
     \item[---] Instantiates a \fiber representing a fiber suspended before
-              entry to \cpp{Entry}.
-              \tsnote{\cpp{Entry} is entered only when \anyresume is called.}
+              entry to \cpp{entry\_copy}.
+              \tsnote{\cpp{entry\_copy} is entered only when \anyresume is called.}
     \item[---] The new fiber's function call stack and any other necessary
               resources are created.
 \end{description}
@@ -211,12 +217,12 @@ calling fiber.
 
 \effects
 \begin{description}
-    \item[---] Let \cpp{Entry} be saved as-if by \emph{decay-copy}\cpp{(std::forward<F>(entry))}.
-    \item[---] Let \cpp{Stack} be saved as-if by \emph{decay-copy}\cpp{(stack)}.
-    \item[---] Let \cpp{Deleter} be saved as-if by \emph{decay-copy}\cpp{(std::forward<D>(deleter))}.
+    \item[---] Let \cpp{entry\_copy} be saved as-if by \emph{decay-copy}\cpp{(std::forward<F>(entry))}.
+    \item[---] Let \cpp{stack\_copy} be saved as-if by \emph{decay-copy}\cpp{(stack)}.
+    \item[---] Let \cpp{deleter\_copy} be saved as-if by \emph{decay-copy}\cpp{(std::forward<D>(deleter))}.
     \item[---] Instantiates a \fiber representing a fiber suspended before
-              entry to \cpp{Entry}.
-              \tsnote{\cpp{Entry} is entered only when \anyresume is called.}
+              entry to \cpp{entry\_copy}.
+              \tsnote{\cpp{entry\_copy} is entered only when \anyresume is called.}
     \item[---] The contiguous block of uninitialized memory referenced
               by \cpp{stack} is set up as the new fiber's function call stack.
               \tsnote{It is the caller's responsibility to provide a span of
@@ -264,7 +270,7 @@ calling fiber.
 \effects
 \begin{description}
     \item[---] Destroys a \fiber instance.
-    \item[---] If \emptyfn returns \false, invokes \cpp{terminate} ([except.terminate]).
+    \item[---] If \emptyfn returns \false, invokes \cpp{terminate} (\stdclause{except.terminate}).
 \end{description}
 
 \tsnote{If a \fiber instance to be destroyed is not yet empty, an application
@@ -322,14 +328,14 @@ must convey to the suspended fiber the need to terminate voluntarily.}
     \item[---] If \cpp{target} has not previously been
                entered, passes \cpp{returned} to its \entryfn. Let \continuation
                be the result of executing
-               \cpp{invoke\_r<fiber\_context>(Entry, std::move(returned))}. On return:
+               \cpp{invoke\_r<fiber\_context>(entry\_copy, std::move(returned))}. On return:
         \begin{itemize}
             \item restores the execution context of \continuation
-            \item destroys \cpp{Entry}
-            \item if \cpp{target} has an associated \cpp{Stack} and \cpp{Deleter}:
+            \item destroys \cpp{entry\_copy}
+            \item if \cpp{target} has an associated \cpp{stack\_copy} and \cpp{deleter\_copy}:
                 \begin{itemize}
-                    \item executes \cpp{invoke(Deleter, Stack)}
-                    \item destroys \cpp{Deleter}
+                    \item executes \cpp{invoke(deleter\_copy, stack\_copy)}
+                    \item destroys \cpp{deleter\_copy}
                 \end{itemize}
             \item otherwise reclaims the implementation-provided stack
             \item resumes \continuation as if by \cpp{continuation.resume()}.
@@ -367,11 +373,11 @@ must convey to the suspended fiber the need to terminate voluntarily.}
         \item If the previous fiber resumed this one by returning a \fiber:
             \begin{itemize}
                 \item Any exception thrown as a result of destroying the
-                      previous fiber's associated \cpp{Entry}.
+                      previous fiber's associated \cpp{entry\_copy}.
                 \item Any exception thrown by the previous fiber's
-                      associated \cpp{Deleter}.
+                      associated \cpp{deleter\_copy}.
                 \item Any exception thrown as a result of destroying the
-                      previous fiber's associated \cpp{Deleter}.
+                      previous fiber's associated \cpp{deleter\_copy}.
             \end{itemize}
         \item If the previous fiber resumed this one by calling \someresume,
               nothing.

--- a/commands.tex
+++ b/commands.tex
@@ -68,6 +68,13 @@
         stringstyle=\ttfamily\color{magenta}
 ] {code/#1.cpp}}
 
+\newcommand{\red}[1]{\colorbox{red}{#1}}
+\newcommand{\green}[1]{\colorbox{green}{#1}}
+\newcommand{\delete}[1]{\red{#1}}
+%% \insert is already defined, with a different meaning
+\newcommand{\add}[1]{\green{#1}}
+\newcommand{\replace}[2]{\delete{#1}\add{#2}}
+\newcommand{\stdclause}[1]{\href{https://eel.is/c++draft/#1}{[#1]}}
 \newcommand{\true}{\cpp{true}}
 \newcommand{\false}{\cpp{false}}
 \newcommand{\dtor}{\cpp{\~fiber\_context()}}
@@ -108,10 +115,10 @@
 \newcommand{\this}{\cpp{*this}}
 \newcommand{\unwindex}{\cpp{std::unwind\_exception}}
 \newcommand{\unwindfib}{\cpp{std::unwind\_fiber()}}
-\newcommand{\uwforced}{\cpp{_Unwind_ForcedUnwind()}}
-\newcommand{\curex}{\cpp{std::current_exception()}}
-\newcommand{\uncex}{\cpp{std::uncaught_exception()}}
-\newcommand{\uncexs}{\cpp{std::uncaught_exceptions()}}
+\newcommand{\uwforced}{\cpp{\_Unwind\_ForcedUnwind()}}
+\newcommand{\curex}{\cpp{std::current\_exception()}}
+\newcommand{\uncexs}{\cpp{std::uncaught\_exceptions()}}
+\newcommand{\exfns}{\uncexs and \curex}
 \newcommand{\catchall}{\cpp{catch (...)}}
 \newcommand{\swapcontext}{\cpp{swapcontext()}}
 \newcommand{\seeappalaunch}{(See \nameref{appendixa} for the definition of \cpp{autocancel}.)}

--- a/implementation.tex
+++ b/implementation.tex
@@ -105,3 +105,20 @@ passed (or returned) into the resumed fiber (see \nameref{synthesizing}).
 
 \zs{Using the active fiber's stack as storage for the CPU state is efficient because no
 additional allocations or deallocations are required.}
+
+\uabschnitt{\exfns}
+
+Both \exfns must report exceptions solely on the current thread of execution.
+Reporting exceptions on any other thread of execution would make them
+unreliable in practice.
+
+A straightforward implementation could make \allresume save and restore the
+data underlying \exfns as part of saving and restoring the rest of the fiber
+state. Since \exfns data is necessarily thread-local, the likely cost would be
+a TLS access on every \anyresume call.
+
+Alternatively, \fiber's constructor could update an internal associative
+container whose key is the high end of the new fiber stack. \exfns could
+call \cpp{upper\_bound()}, passing the current stack pointer, to discover
+which stack is current. This would shift the cost from every context switch
+to \exfns calls.

--- a/references.tex
+++ b/references.tex
@@ -33,8 +33,8 @@
         {N3985: A proposal to add coroutines to the C++ standard library}
 
     \bibitem{Standard}
-        \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/n4917.pdf}
-        {N4917: Working Draft, Standard for Programming Language C++}
+        \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/n4928.pdf}
+        {N4928: Working Draft, Standard for Programming Language C++}
 
     \bibitem{P0099R0}
         \href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0099r0.pdf}

--- a/termination.tex
+++ b/termination.tex
@@ -157,7 +157,7 @@ above.
 %% As a consequence, \curex can not return a \cpp{std::exception\_ptr} pointing
 %% to a \foreignex.
 %% 
-%% In order to detect if stack unwinding is currently in progress \uncex returns \true and\\
+%% In order to detect if stack unwinding is currently in progress\\
 %% \uncexs counts the \foreignex.
 %% 
 %% The rationale for moving to an uncatchable exception is further explained in


### PR DESCRIPTION
Modify the existing clauses defining their semantics to reference "the current thread of execution."

Make references to existing Standard clauses links to https://eel.is/c++draft.

Add a note in the implementation section discussing a couple ways to implement fiber-local std::uncaught_exceptions and std::current_exception.

Also clarify the names of the copies of fiber_context constructor arguments entry, stack, deleter.