### PR TITLE
Prepare P0876R19 for Hagenberg, Austria, February 2025

### DIFF
--- a/P0876.tex
+++ b/P0876.tex
@@ -62,7 +62,7 @@
 \begin{document}
 \small
 \begin{tabbing}
-    Document number: \= P0876R19\\
+    Document number: \= D0876R20\\
     Date:            \> 2025-01-11\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\

--- a/P0876.tex
+++ b/P0876.tex
@@ -63,7 +63,7 @@
 \small
 \begin{tabbing}
     Document number: \= P0876R19\\
-    Date:            \> 2024-10-16\\
+    Date:            \> 2025-01-11\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> LWG, CWG, EWG\\
@@ -101,6 +101,9 @@
 \input{tls}
 \input{acknowledgment}
 \input{api}
+\input{exlife}
+\input{throw}
+\input{exfns}
 \input{for_examples}
 \input{references}
 

--- a/P0876.tex
+++ b/P0876.tex
@@ -63,7 +63,7 @@
 \small
 \begin{tabbing}
     Document number: \= D0876R20\\
-    Date:            \> 2025-01-11\\
+    Date:            \> 2025-02-14\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
     Audience:        \> LWG, CWG, EWG\\

--- a/P0876.tex
+++ b/P0876.tex
@@ -62,7 +62,7 @@
 \begin{document}
 \small
 \begin{tabbing}
-    Document number: \= D0876R20\\
+    Document number: \= P0876R20\\
     Date:            \> 2025-02-14\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\
@@ -80,6 +80,7 @@
 \input{abstract}
 \input{history}
 \newpage
+\input{counter_p3620}
 \input{ecosystem}
 \input{control_transfer}
 \input{first_class}

--- a/P0876.tex
+++ b/P0876.tex
@@ -62,7 +62,7 @@
 \begin{document}
 \small
 \begin{tabbing}
-    Document number: \= P0876R18\\
+    Document number: \= P0876R19\\
     Date:            \> 2024-10-16\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat@lindenlab.com)\\

--- a/abstract.tex
+++ b/abstract.tex
@@ -8,7 +8,7 @@ constructs such as stackful coroutines as well as cooperative multitasking
 
 This revision addresses concerns, questions and suggestions from the past meetings.
 The proposed API supersedes the former proposals N3985\cite{N3985},
-P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3} and P0876R18\cite{P0876R18}.
+P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3} and P0876R19\cite{P0876R19}.
 
 Because of name clashes with \emph{coroutine} from C++20,
 \emph{execution context} from executor proposals and \emph{continuation} used

--- a/abstract.tex
+++ b/abstract.tex
@@ -19,3 +19,7 @@ term \emph{fiber} for a higher-level facility built on top of this one.
 
 Informally within this proposal, the term \emph{fiber} is used to denote the
 flow of control launched and represented by the first-class object \fiber.
+
+It's telling that when Hana Dusikova was working on implementations of P3367R3
+constexpr coroutines\cite{P3367R3}, the ``easiest way to model a coroutine,''
+the ``obvious first choice,'' was to use fibers in the constexpr evaluator.

--- a/abstract.tex
+++ b/abstract.tex
@@ -8,7 +8,7 @@ constructs such as stackful coroutines as well as cooperative multitasking
 
 This revision addresses concerns, questions and suggestions from the past meetings.
 The proposed API supersedes the former proposals N3985\cite{N3985},
-P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3} and P0876R17\cite{P0876R17}.
+P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3} and P0876R18\cite{P0876R18}.
 
 Because of name clashes with \emph{coroutine} from C++20,
 \emph{execution context} from executor proposals and \emph{continuation} used

--- a/code/fccurrexc.cpp
+++ b/code/fccurrexc.cpp
@@ -1,0 +1,110 @@
+fiber_context other_fiber;
+
+void yield()
+{
+    assert(other_fiber);
+    // We switch back and forth between two fibers, A and B. One is running,
+    // the other is suspended. When fiber A calls yield():
+    //  1. other_fiber is emptied
+    //  2. the lambda is called on fiber B
+    //  3. other_fiber is set to fiber A
+    //  4. fiber B receives empty fiber_context, which is ignored
+    //  5. fiber B runs for a while
+    //  6. fiber B calls yield()
+    //  7. other_fiber is emptied
+    //  8. the lambda is called on fiber A
+    //  9. other_fiber is set to fiber B
+    // 10. fiber A receives empty fiber_context, which is ignored
+    // 11. fiber A runs for a while...
+    std::move(other_fiber).resume_with(
+        [](fiber_context&& prev)
+        {
+            other_fiber = std::move(prev);
+            return fiber_context{};
+        });
+}
+
+void uncaughts(std::string name)
+{
+    std::cout << "  " << name << ": std::uncaught_exceptions() = "
+              << std::uncaught_exceptions() << std::endl;
+}
+
+void current(std::string name)
+{
+    auto exc = std::current_exception();
+    if (! exc)
+    {
+        std::cout << "  " << name << ": std::current_exception() = nullptr" << std::endl;
+    }
+    else
+    {
+        try
+        {
+            std::rethrow_exception(exc);
+        }
+        catch (const std::exception& err)
+        {
+            std::cout << "  " << name << ": std::current_exception() = " << err.what() << std::endl;
+        }
+    }
+}
+
+void hop(std::string name)
+{
+    std::cout << name << " suspending:" << std::endl;
+    std::string before{ name + " before" };
+    uncaughts(before);
+    current(before);
+    yield();
+    std::cout << name << " resuming:" << std::endl;
+    std::string after{ name + " after" };
+    uncaughts(after);
+    current(after);
+}
+
+struct destruct
+{
+    destruct(std::string name): mName(name + ": ~destruct()") {}
+    ~destruct()
+    {
+        hop(mName);
+    }
+    std::string mName;
+};        
+
+void testcode(std::string name)
+{
+    try
+    {
+        destruct d(name);
+        std::string exname = name + " exception";
+        std::cout << "throw " << exname << std::endl;
+        throw std::runtime_error(exname);
+    }
+    catch (const std::exception& err)
+    {
+        std::cout << name << " caught " << err.what() << std::endl;
+        hop(name + " catch block");
+    }
+}
+
+fiber_context fiber(fiber_context&&)
+{
+    std::cout << "fiber() starting" << std::endl;
+    testcode("fiber()");
+    std::cout << "fiber() ending" << std::endl;
+    assert(other_fiber);
+    return std::move(other_fiber);
+}
+
+int main(int argc, char *argv[])
+{
+    std::cout << "main() starting" << std::endl;
+    other_fiber = fiber_context(fiber);
+    hop("main()");
+    testcode("main()");
+    std::cout << "main() ending" << std::endl;
+    assert(! other_fiber);
+    return 0;
+}

--- a/commands.tex
+++ b/commands.tex
@@ -197,6 +197,9 @@
 \newcommand{\photon}{
         \href{https://github.com/alibaba/PhotonLibOS}
         {\emph{Photon}}}
+\newcommand{\statethreads}{
+        \href{https://github.com/ossrs/state-threads}
+        {\emph{state-threads}}}
 \newcommand{\synca}{
         \href{https://github.com/gridem/Synca}
         {\emph{Synca}}}

--- a/commands.tex
+++ b/commands.tex
@@ -167,6 +167,9 @@
 \newcommand{\bfiber}{
         \href{http://www.boost.org/doc/libs/release/libs/fiber/doc/html/index.html}
         {\emph{Boost.Fiber}}}
+\newcommand{\bthread}{
+        \href{https://brpc.apache.org/docs/bthread/}
+        {\emph{bthread}}}
 \newcommand{\fbmcrouter}{
         \href{https://code.facebook.com/posts/296442737213493/introducing-mcrouter-a-memcached-protocol-router-for-scaling-memcached-deployments}
         {\emph{mcrouter}}}
@@ -182,6 +185,18 @@
 \newcommand{\hclib}{
         \href{https://github.com/habanero-rice/hclib}
         {\emph{HClib}}}
+\newcommand{\libco}{
+        \href{https://github.com/Tencent/libco}
+        {\emph{libco}}}
+\newcommand{\libeasy}{
+        \href{https://github.com/oceanbase/oceanbase/tree/develop/deps/easy}
+        {\emph{libeasy}}}
+\newcommand{\libgo}{
+        \href{https://github.com/yyzybb537/libgo}
+        {\emph{libgo}}}
+\newcommand{\photon}{
+        \href{https://github.com/alibaba/PhotonLibOS}
+        {\emph{Photon}}}
 \newcommand{\synca}{
         \href{https://github.com/gridem/Synca}
         {\emph{Synca}}}

--- a/commands.tex
+++ b/commands.tex
@@ -141,7 +141,7 @@
 \newcommand{\exfns}{\uncexs and \curex}
 \newcommand{\catchall}{\cpp{catch (...)}}
 \newcommand{\swapcontext}{\cpp{swapcontext()}}
-\newcommand{\seeappalaunch}{(See \nameref{appendixa} for the definition of \cpp{autocancel}.)}
+\newcommand{\seeautocancel}{(See \nameref{autocancel} for the definition of \cpp{autocancel}.)}
 
 \newcommand{\sym}{\emph{symmetric}\xspace}
 \newcommand{\asym}{\emph{asymmetric}\xspace}

--- a/counter_p3620.tex
+++ b/counter_p3620.tex
@@ -1,0 +1,61 @@
+\abschnitt{P3620R0: Concerns with the proposed addition of fibers to C++26}
+
+At a high level, P3620R0\cite{P3620R0} appears to argue that unless fibers are
+appropriate for all use cases, they must not be available for any use case.
+This ignores the industry experience cited in \nameref{low_level}.
+
+Not every C++ feature is applicable to every environment. \cpp{breakpoint()}
+is not generally found in production code. A library that writes to
+\cpp{std::cerr} will cause problems for an application running in a windowed
+environment that has no stderr file handle. A library that throws exceptions
+is a poor choice for an application that forbids exceptions. A library that
+creates \cpp{std::thread}s will cause trouble for an application that's not
+expecting them.
+
+\uabschnitt{Fibers are not lightweight threads}
+
+P3620R0 states that operating system vendors have largely abandoned attempts
+to support fibers as N:M threading, because operating system threads have more
+state than it's feasible to manage with fibers.
+
+\fiber does not claim to support lightweight threads. \fiber is a tool for
+organizing the flow of control within an operating system thread. It does not
+need to manage signals, signal masks or other facilities beyond the C++
+abstract machine.
+
+\uabschnitt{TLS}
+
+P3620R0 notes that \tlocal storage is shared between all the fibers on a
+thread. P3346R0\cite{P3346R0} proposed to modify \tlocal to mean
+fiber-specific. This was rejected by SG1 in Wrocław.\cite{wroclawp3346}
+
+This semantic can nonetheless be addressed by a higher-level library. For
+instance, Boost.Fiber\cite{bfiber} provides
+\href{https://www.boost.org/doc/libs/release/libs/fiber/doc/html/fiber/fls.html}
+{\cpp{fiber\_specific\_ptr}}.
+
+P3620R0 further claims that C++20 coroutines do not have this problem.
+Actually, they do. If, on entry, a coroutine links an object into a linked
+list anchored with a \cpp{static} or \tlocal pointer, then unlinks it on final
+return, reaching that coroutine from different interleaved invocation
+sequences will corrupt that linked list. This issue did not block adoption
+of C++20 coroutines.
+
+It may be worth noting that coroutines provide no entity analogous to a fiber.
+It would not be straightforward to support chain-of-coroutines-local storage.
+
+\uabschnitt{Deadlocks}
+
+P3620R0 points out that switching fibers within a thread while holding a lock
+may lead to accidental deadlock.
+
+This semantic can be addressed by a higher-level library. For instance,
+Boost.Fiber\cite{bfiber} provides fiber-aware synchronization primitives such as
+\href{https://www.boost.org/doc/libs/release/libs/fiber/doc/html/fiber/synchronization/mutex_types.html}
+{\cpp{boost::fibers::mutex}}.
+
+C++20 coroutines have the same problem. This issue did not block adoption of
+C++20 coroutines.
+
+It would not be straightforward to support chain-of-coroutines-aware
+synchronization primitives.

--- a/exfns.tex
+++ b/exfns.tex
@@ -1,0 +1,27 @@
+\newpage
+\abschnitt{Appendix C: \exfns}\label{exfns}
+
+\href{https://github.com/secondlife/3p-boost/blob/nat/exstate/tests/fccurrexc.cpp}{The following program}
+illustrates the output of \exfns in cases involving fiber context
+switches within a destructor invoked by exception handling, and within a catch
+block.
+
+\cppf{fccurrexc}
+
+With fiber-specific exception state, \uncexs never exceeds 1, and \curex
+displays:
+
+\cpp{fiber() catch block after: std::current\_exception() = fiber() exception}
+
+and:
+
+\cpp{main() catch block after: std::current\_exception() = main() exception}
+
+Without fiber-specific exception state, \uncexs displays up to 2 (one
+exception in \main, one in \cpp{fiber()}), and \curex displays:
+
+\cpp{fiber() catch block after: std::current\_exception() = main() exception}
+
+and:
+
+\cpp{main() catch block after: std::current\_exception() = fiber() exception}

--- a/exlife.tex
+++ b/exlife.tex
@@ -1,0 +1,13 @@
+\newpage
+\abschnitt{Appendix A: potential premature destruction of exception object}\label{exlife}
+
+In \stdclause{except.throw} paragraph 4, the destruction of an exception
+object is specified to potentially occur when an active handler for the
+exception exits, not when a handler exits while the exception is still the
+currently handled exception. It is possible to observe, with the Boost
+implementation in an Itanium C++ ABI environment, cases where an exception is
+destroyed at a different point than specified (and, in particular, when a
+handler for the exception is still active in a fiber). Consider
+\href{https://github.com/secondlife/3p-boost/blob/nat/exstate/tests/early_exc_destroy.cpp}{the following program}.
+
+\cppf{early_exc_destroy}

--- a/for_examples.tex
+++ b/for_examples.tex
@@ -1,5 +1,5 @@
 \newpage
-\abschnitt{Appendix A: support code for examples}\label{launch}\label{appendixa}
+\abschnitt{Appendix D: support code for examples}\label{autocancel}
 
 Destroying a non-empty \fiber instance invokes Undefined Behaviour
 (see \nameref{termination}). To simplify code examples in this paper, we

--- a/history.tex
+++ b/history.tex
@@ -5,8 +5,9 @@ This document supersedes P0876R19.
 
 \begin{itemize}
     \item Add information about implementability of per-fiber exception state.
-    \item Add links to St. Louis 2024 EWG notes, Wroclaw 2024 EWG notes and
+    \item Add links to St. Louis 2024 EWG notes, Wrocław 2024 EWG notes and
           Microsoft implementability email.
+    \item Add discussion of P3620R0.
 \end{itemize}
 
 \uabschnitt{Changes since P0876R18}

--- a/history.tex
+++ b/history.tex
@@ -1,5 +1,7 @@
 \abschnitt{Revision History}\label{history}
-This document supersedes P0876R17.
+This document supersedes P0876R18.
+
+\uabschnitt{Changes since P0876R18}
 
 \uabschnitt{Changes since P0876R17}
 

--- a/history.tex
+++ b/history.tex
@@ -7,6 +7,8 @@ This document supersedes P0876R18.
     \item Move exception state test programs to Appendices.
     \item Link Boost.Context patch that produces correct fiber-specific
           exception behavior on Windows and Linux using libstdc++.
+    \item Add references to six additional production libraries built on fiber
+          technology.
 \end{itemize}
 
 \uabschnitt{Changes since P0876R17}

--- a/history.tex
+++ b/history.tex
@@ -8,6 +8,7 @@ This document supersedes P0876R19.
     \item Add links to St. Louis 2024 EWG notes, Wrocław 2024 EWG notes and
           Microsoft implementability email.
     \item Add discussion of P3620R0.
+    \item Mention P3367R3 constexpr coroutines.
 \end{itemize}
 
 \uabschnitt{Changes since P0876R18}

--- a/history.tex
+++ b/history.tex
@@ -3,6 +3,12 @@ This document supersedes P0876R19.
 
 \uabschnitt{Changes since P0876R19}
 
+\begin{itemize}
+    \item Add information about implementability of per-fiber exception state.
+    \item Add links to St. Louis 2024 EWG notes, Wroclaw 2024 EWG notes and
+          Microsoft implementability email.
+\end{itemize}
+
 \uabschnitt{Changes since P0876R18}
 
 \begin{itemize}

--- a/history.tex
+++ b/history.tex
@@ -1,5 +1,7 @@
 \abschnitt{Revision History}\label{history}
-This document supersedes P0876R18.
+This document supersedes P0876R19.
+
+\uabschnitt{Changes since P0876R19}
 
 \uabschnitt{Changes since P0876R18}
 

--- a/history.tex
+++ b/history.tex
@@ -3,6 +3,12 @@ This document supersedes P0876R18.
 
 \uabschnitt{Changes since P0876R18}
 
+\begin{itemize}
+    \item Move exception state test programs to Appendices.
+    \item Link Boost.Context patch that produces correct fiber-specific
+          exception behavior on Windows and Linux using libstdc++.
+\end{itemize}
+
 \uabschnitt{Changes since P0876R17}
 
 \begin{itemize}

--- a/implementation.tex
+++ b/implementation.tex
@@ -135,7 +135,7 @@ simply to forbid coders from switching fibers within a catch block.
 In St. Louis in June 2024, EWG requested\cite{stlouisnotes} implementation
 experience with fiber-specific exception state.
 
-In Wroclaw in November 2024,\cite{wroclawnotes} we presented
+In Wrocław in November 2024,\cite{wroclawnotes} we presented
 \href{https://github.com/secondlife/3p-boost/blob/nat/exstate/patches/libs/context/0001-switch-exception-state.patch}{a small patch}
 to the Boost.Context reference implementation. With that patch, all three
 exception state test programs behave correctly when built with libstdc++ on

--- a/implementation.tex
+++ b/implementation.tex
@@ -132,7 +132,18 @@ fibers is that a function need not know whether some function it calls (or
 some indirect callee thereof) will resume another fiber. It's not practical
 simply to forbid coders from switching fibers within a catch block.
 
-It's worth pointing out that with
+In St. Louis in June 2024, EWG requested\cite{stlouisnotes} implementation
+experience with fiber-specific exception state.
+
+In Wroclaw in November 2024,\cite{wroclawnotes} we presented
 \href{https://github.com/secondlife/3p-boost/blob/nat/exstate/patches/libs/context/0001-switch-exception-state.patch}{a small patch}
-to the Boost.Context reference implementation, all three programs behave
-correctly when built with libstdc++ on Windows and Linux.
+to the Boost.Context reference implementation. With that patch, all three
+exception state test programs behave correctly when built with libstdc++ on
+Windows and Linux. Microsoft questioned whether fiber-specific exception state
+is implementable in MSVC, and EWG agreed to take up this matter in Hagenberg.
+
+On February 14, 2025, Gor Nishanov stated\cite{onwindows} that a Windows
+Fibers implementation of \fiber would be possible, while expressing concern
+about potential performance.
+
+

--- a/implementation.tex
+++ b/implementation.tex
@@ -108,7 +108,7 @@ additional allocations or deallocations are required.}
 
 \abschnitt{\exfns}\label{exc_scope}
 
-Both \exfns should report exceptions solely on the current fiber.
+Both \exfns must report exceptions solely on the current fiber.
 Reporting exceptions thrown on any other fiber would make them
 unreliable in practice.
 
@@ -123,61 +123,16 @@ call \cpp{upper\_bound()}, passing the current stack pointer, to discover
 which stack is current. This would shift the cost from every context switch
 to \exfns calls.
 
-As of 2023, though, the zeitgeist appears to be that \exfns are not sufficiently
-important to warrant altering exception-handling implementations to fix their
-behavior. This is why, in the \nameref{api} section, it is
-implementation-defined whether \exfns are specific to the current fiber
-or the current \thread.
+The examples in \nameref{exlife}, \nameref{throw} and
+\nameref{exfns} have been floated to illustrate problems that can
+arise when \exfns are not specific to the current fiber.
 
-The following examples have been floated to illustrate problems that can arise
-when \exfns are not local to the current fiber.
-
-In these small examples, the problematic code is obvious. But the power of
+In those small examples, the problematic code is obvious. But the power of
 fibers is that a function need not know whether some function it calls (or
 some indirect callee thereof) will resume another fiber. It's not practical
 simply to forbid coders from switching fibers within a catch block.
 
-\uabschnitt{Premature destruction of exception object}
-
-In \stdclause{except.throw} paragraph 4, the destruction of an exception
-object is specified to potentially occur when an active handler for the
-exception exits, not when a handler exits while the exception is still the
-currently handled exception. It is possible to observe, with the Boost
-implementation in an Itanium C++ ABI environment, cases where an exception is
-destroyed at a different point than specified (and, in particular, when a
-handler for the exception is still active in a fiber).
-
-\cppf{early_exc_destroy}
-
-\uabschnitt{Throw-expression with no operand}
-
-Both \stdclause{expr.throw} paragraph 3 and \cpp{current\_exception()}
-(\stdclause{propagation} paragraph 8) reference the ``currently handled
-exception'' (\stdclause{except.handle} paragraph 8). Thus, the
-construct \cpp{throw;} is by definition equivalent to
-\cpp{std::rethrow\_exception(std::current\_exception());}
-(\stdclause{propagation} paragraph 9).
-
-The existing definition of currently handled exception:
-
-``The exception with the most recently activated handler that is still active
-is called the \emph{currently handled exception.}''
-
-does not clearly constrain the scope to the current thread. This constraint
-must be inferred from \stdclause{except.throw} paragraph 2:
-
-``When an exception is thrown, control is transferred to the nearest handler
-with a matching type \xref{except.handle}; ``nearest'' means the handler for
-which the \nt{stmt.block}{compound-statement} or
-\nt{class.base.init}{ctor-initializer} following the \cpp{try} keyword was
-most recently entered by the thread of control and not yet exited.''
-
-In any case, if ``currently handled exception'' means the exception with the
-most recently activated handler within any fiber on the current thread, we can
-get the following result.
-
-\cppfl{nullary_throw}
-
-Worse still, the exceptions in question aren't necessarily related to each
-other, and line 36 is more likely to read \cpp{catch (const Bad& caught)} --
-in which case the \cpp{throw;} on line 34 would \emph{not} be caught.
+It's worth pointing out that with
+\href{https://github.com/secondlife/3p-boost/blob/nat/exstate/patches/libs/context/0001-switch-exception-state.patch}{a small patch}
+to the Boost.Context reference implementation, all three programs behave
+correctly when built with libstdc++ on Windows and Linux.

--- a/low_level.tex
+++ b/low_level.tex
@@ -97,8 +97,7 @@ in China, with billions of users.
 
 \uabschnitt{\libgo}\cite{libgo} is developed by Meizu, one of the top mobile
 phone vendors in China. Libgo is used in Kiev, Meizu's distributed service
-framework for its applications. Libgo does support parallel scheduling
-for multi-core CPUs.
+framework for its applications.
 
 \uabschnitt{\statethreads}\cite{state-threads} was first developed by
 Netscape, then maintained by SGI and Yahoo!. It is now used in a realtime

--- a/low_level.tex
+++ b/low_level.tex
@@ -78,6 +78,24 @@ framework with a rich set of abstractions, database connectors/drivers,
 protocols and synchronization primitives for fast and comfortable creation
 of IO-bound C++ microservices, services and utilities.
 
+\uabschnitt{Alibaba's \photon}\cite{photon} supports a large number of services
+and clients, especially the image service of Alibaba’s container platform,
+which supports various Internet services for billions of users.
+Also used in some ByteDance services.
+
+\uabschnitt{Alibaba's \libeasy}\cite{libeasy} supports a large number of
+servers, including storage, database, etc. Not officially open-sourced, but
+carried out by some open source projects, such as Oceanbase, tair, etc.
+
+\uabschnitt{Baidu's \bthread}\cite{bthread} has 1 million+ deployed instances
+(not counting clients) and thousands of kinds of services.
+
+\uabschnitt{Tencent's \libco}\cite{libco} is a c/c++ coroutine library that
+is widely used in backend service of WeChat, which is the largest IM service
+in China, with billions of users. 
+
+\uabschnitt{\libgo}\cite{libgo} is said to be developed by Meizu.
+
 \zs{As shown in this section a low-level API can act as building block for a
 rich set of high-level frameworks designed for specific application domains
 that require different aspects of design, semantics and syntax.}

--- a/low_level.tex
+++ b/low_level.tex
@@ -85,7 +85,8 @@ Also used in some ByteDance services.
 
 \uabschnitt{Alibaba's \libeasy}\cite{libeasy} supports a large number of
 servers, including storage, database, etc. Not officially open-sourced, but
-carried out by some open source projects, such as Oceanbase, tair, etc.
+has been published as part of some open source projects, such as Oceanbase,
+tair, etc.
 
 \uabschnitt{Baidu's \bthread}\cite{bthread} has 1 million+ deployed instances
 (not counting clients) and thousands of kinds of services.
@@ -94,7 +95,17 @@ carried out by some open source projects, such as Oceanbase, tair, etc.
 is widely used in backend service of WeChat, which is the largest IM service
 in China, with billions of users. 
 
-\uabschnitt{\libgo}\cite{libgo} is said to be developed by Meizu.
+\uabschnitt{\libgo}\cite{libgo} is developed by Meizu, one of the top mobile
+phone vendors in China. Libgo is used in Kiev, Meizu's distributed service
+framework for its applications. Libgo does support parallel scheduling
+for multi-core CPUs.
+
+\uabschnitt{\statethreads}\cite{state-threads} was first developed by
+Netscape, then maintained by SGI and Yahoo!. It is now used in a realtime
+media streaming server called \href{https://github.com/ossrs/srs}{SRS}, and
+maintained by SRS's developers. \emph{state-threads} was used in the
+\href{https://dl.acm.org/doi/10.1145/3302424.3303967}
+{distributed block store for Meituan}, another top Internet company in China.
 
 \zs{As shown in this section a low-level API can act as building block for a
 rich set of high-level frameworks designed for specific application domains

--- a/references.tex
+++ b/references.tex
@@ -129,6 +129,10 @@
         \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p0876r18.pdf}
         {P0876R18: fibers without scheduler}
 
+    \bibitem{P0876R19}
+        \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p0876r19.pdf}
+        {P0876R19: fibers without scheduler}
+
     \bibitem{P1677R2}
         \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1677r2.pdf}
         {P1677R2: Cancellation is serendipitous-success}

--- a/references.tex
+++ b/references.tex
@@ -174,13 +174,33 @@
         \href{https://github.com/bloomberg/quantum}
         {Bloomberg's \emph{quantum}}
 
+    \bibitem{bthread}
+        \href{https://brpc.apache.org/docs/bthread/}
+        {Baidu's \emph{bthread} in brpc}
+
     \bibitem{habanero}
-		\href{https://wiki.rice.edu/confluence/display/HABANERO/Habanero+Extreme+Scale+Software+Research+Project}
-		{Habanero Extreme Scale Software Research Project}
+        \href{https://wiki.rice.edu/confluence/display/HABANERO/Habanero+Extreme+Scale+Software+Research+Project}
+        {Habanero Extreme Scale Software Research Project}
 
     \bibitem{hclib}
-		\href{https://github.com/habanero-rice/hclib}
-		{Habanero HClib}
+        \href{https://github.com/habanero-rice/hclib}
+        {Habanero HClib}
+
+    \bibitem{libco}
+        \href{https://github.com/Tencent/libco}
+        {Tencent's \emph{libco}}
+
+    \bibitem{libeasy}
+        \href{https://github.com/oceanbase/oceanbase/tree/develop/deps/easy}
+        {Alibaba's \emph{libeasy}}
+
+    \bibitem{libgo}
+        \href{https://github.com/yyzybb537/libgo}
+        {Library \emph{libgo}}
+
+    \bibitem{photon}
+        \href{https://github.com/alibaba/PhotonLibOS}
+        {Alibaba's \emph{Photon}}
 
     \bibitem{synca}
         \href{https://github.com/gridem/Synca}
@@ -188,10 +208,10 @@
 
     \bibitem{tbb}
         \href{https://github.com/intel/tbb}
-        {Intels's \emph{TBB}}
+        {Intel's \emph{TBB}}
 
     \bibitem{userver}
-		\href{https://github.com/userver-framework}
-		{userver - The C++ Framework}
+        \href{https://github.com/userver-framework}
+        {userver - The C++ Framework}
 
 \end{thebibliography}

--- a/references.tex
+++ b/references.tex
@@ -202,6 +202,10 @@
         \href{https://github.com/alibaba/PhotonLibOS}
         {Alibaba's \emph{Photon}}
 
+    \bibitem{state-threads}
+        \href{https://github.com/ossrs/state-threads}
+        {Library \emph{state-threads}}
+
     \bibitem{synca}
         \href{https://github.com/gridem/Synca}
         {Library \emph{Synca}}

--- a/references.tex
+++ b/references.tex
@@ -226,4 +226,16 @@
         \href{https://github.com/userver-framework}
         {userver - The C++ Framework}
 
+    \bibitem{stlouisnotes}
+        \href{https://wiki.edg.com/bin/view/Wg21stlouis2024/NotesEWGP0876}
+        {St. Louis 2024 EWG notes}
+
+    \bibitem{wroclawnotes}
+        \href{https://wiki.edg.com/bin/view/Wg21wroclaw2024/NotesEWGP0876}
+        {Wroclaw 2024 EWG notes}
+
+    \bibitem{onwindows}
+        \href{https://lists.isocpp.org/ext/2025/02/25138.php}
+        {Microsoft feedback on P0876R19 implementability.\& desirability}
+
 \end{thebibliography}

--- a/references.tex
+++ b/references.tex
@@ -145,6 +145,14 @@
         \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2175r0.html}
         {P2175R0: Composable cancellation for sender-based async operations}
 
+    \bibitem{P3346R0}
+        \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3346r0.pdf}
+        {P3346R0: \tlocal means fiber-specific}
+
+    \bibitem{P3620R0}
+        \href{https://isocpp.org/files/papers/P3620R0.pdf}
+        {P3620R0: Concerns with the proposed addition of fibers to C++26}
+
     \bibitem{coreguidlines}
         \href{http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Ri-global}
         {C++ Core Guidelines}
@@ -232,7 +240,11 @@
 
     \bibitem{wroclawnotes}
         \href{https://wiki.edg.com/bin/view/Wg21wroclaw2024/NotesEWGP0876}
-        {Wroclaw 2024 EWG notes}
+        {Wrocław 2024 EWG notes}
+
+    \bibitem{wroclawp3346}
+        \href{https://wiki.edg.com/bin/edit/Wg21wroclaw2024/P3346R0?topicparent=Wg21wroclaw2024.SG1}
+        {Wrocław 2024 SG1 notes on P3346R0}
 
     \bibitem{onwindows}
         \href{https://lists.isocpp.org/ext/2025/02/25138.php}

--- a/references.tex
+++ b/references.tex
@@ -149,6 +149,10 @@
         \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3346r0.pdf}
         {P3346R0: \tlocal means fiber-specific}
 
+    \bibitem{P3367R3}
+        \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3367r3.html}
+        {constexpr coroutines}
+
     \bibitem{P3620R0}
         \href{https://isocpp.org/files/papers/P3620R0.pdf}
         {P3620R0: Concerns with the proposed addition of fibers to C++26}
@@ -249,5 +253,9 @@
     \bibitem{onwindows}
         \href{https://lists.isocpp.org/ext/2025/02/25138.php}
         {Microsoft feedback on P0876R19 implementability.\& desirability}
+
+    \bibitem{hagenbergp3367}
+        \href{https://wiki.edg.com/bin/edit/Wg21hagenberg2025/NotesEWGP3367}
+        {Hagenberg 2025 EWG notes on P3367R3}
 
 \end{thebibliography}

--- a/references.tex
+++ b/references.tex
@@ -125,6 +125,10 @@
         \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p0876r17.pdf}
         {P0876R17: fibers without scheduler}
 
+    \bibitem{P0876R18}
+        \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p0876r18.pdf}
+        {P0876R18: fibers without scheduler}
+
     \bibitem{P1677R2}
         \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1677r2.pdf}
         {P1677R2: Cancellation is serendipitous-success}

--- a/references.tex
+++ b/references.tex
@@ -151,7 +151,7 @@
 
     \bibitem{P3367R3}
         \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3367r3.html}
-        {constexpr coroutines}
+        {P3367R3: constexpr coroutines}
 
     \bibitem{P3620R0}
         \href{https://isocpp.org/files/papers/P3620R0.pdf}

--- a/rev
+++ b/rev
@@ -34,21 +34,26 @@ esac
 
 # There should be only one master .tex file, but in case we turn up more than
 # one, reverse-sort names, skipping the first character, and take the first.
-oldtex="$(ls [PD]${PNUM}R*.tex | sort -k1.2r | head -n 1)"
-oldrev="${oldtex%.tex}"
+##oldtex="$(ls [PD]${PNUM}R*.tex | sort -k1.2r | head -n 1)"
+# We've gone to a single canonical master .tex file model.
+oldtex="P${PNUM}.tex"
+##oldrev="${oldtex%.tex}"
+# That means we must extract oldrev from that file.
+# e.g. '    Document number: \= P0876R18\\'
+oldrev="$(sed -n -E "s/^ *Document number: .= (P${PNUM}R.*)\\\\\\\\/\1/p" "$oldtex")"
 
 # Find the URL for the published oldrev
 oldurl="$(curl --silent --location --head --output /dev/null --write-out '%{url_effective}' -- https://wg21.link/$oldrev)"
 
 # Find the rev previous to oldrev
-prevrev="$(sed -n -E "s/^.*supersedes ([PD]0876R.*)\..*/\1/p" history.tex)"
+prevrev="$(sed -n -E "s/^.*supersedes ([PD]${PNUM}R.*)\..*/\1/p" history.tex)"
 
 echo "Updating $oldrev -> $newrev"
 echo "$oldrev URL: $oldurl"
 echo "Previous to $oldrev was $prevrev"
 
-git mv "$oldtex" "$newrev.tex"
-sed -i~ "s/$oldrev/$newrev/" "$newrev.tex"
+##git mv "$oldtex" "$newrev.tex"
+sed -i~ "s/$oldrev/$newrev/" "$oldtex"
 sed -i~ "s/$prevrev\\\\cite{$prevrev}/$oldrev\\\\cite{$oldrev}/" abstract.tex
 
 # For 'This document supersedes $prevrev', just update to $oldrev.

--- a/stl.tex
+++ b/stl.tex
@@ -5,7 +5,7 @@ generate a sequence of Fibonacci numbers and store them into \cpp{std::vector}
 \cpp{v}.
 \cppf{generator}
 
-\seeappalaunch
+\seeautocancel
 
 \zs{The proposed fiber API does not require modifications of the STL and can be
 used together with existing STL algorithms.}

--- a/termination.tex
+++ b/termination.tex
@@ -87,7 +87,7 @@ returns another \fiber instance \cpp{f2}.
           present state of fiber F.
 \end{itemize}
 
-The \cpp{autocancel} class introduced in \nameref{launch} illustrates a
+The \cpp{autocancel} class introduced in \nameref{autocancel} illustrates a
 possible cancellation implementation, subject to the limitations described
 above.
 

--- a/throw.tex
+++ b/throw.tex
@@ -1,0 +1,33 @@
+\newpage
+\abschnitt{Appendix B: throw-expression with no operand}\label{throw}
+
+Both \stdclause{expr.throw} paragraph 3 and \cpp{current\_exception()}
+(\stdclause{propagation} paragraph 8) reference the ``currently handled
+exception'' (\stdclause{except.handle} paragraph 8). Thus, the
+construct \cpp{throw;} is by definition equivalent to\\
+\cpp{std::rethrow\_exception(std::current\_exception());}
+(\stdclause{propagation} paragraph 9).
+
+The existing definition of currently handled exception:
+
+``The exception with the most recently activated handler that is still active
+is called the \emph{currently handled exception.}''
+
+does not clearly constrain the scope to the current thread. This constraint
+must be inferred from \stdclause{except.throw} paragraph 2:
+
+``When an exception is thrown, control is transferred to the nearest handler
+with a matching type \xref{except.handle}; ``nearest'' means the handler for
+which the \nt{stmt.block}{compound-statement} or
+\nt{class.base.init}{ctor-initializer} following the \cpp{try} keyword was
+most recently entered by the thread of control and not yet exited.''
+
+In any case, if ``currently handled exception'' means the exception with the
+most recently activated handler within any fiber on the current thread, we can get
+\href{https://github.com/secondlife/3p-boost/blob/nat/exstate/tests/nullary_throw.cpp}{the following result}.
+
+\cppfl{nullary_throw}
+
+Worse still, the exceptions in question aren't necessarily related to each
+other, and line 36 is more likely to read \cpp{catch (const Bad& caught)} --
+in which case the \cpp{throw;} on line 34 would \emph{not} be caught.


### PR DESCRIPTION
Add link to Windows, Linux successful libstdc++ Boost.Context patch.

Move existing exception-state test programs to Appendix A and B, and add
Appendix C with test program displaying std::current_exception() and
std::uncaught_exceptions() under various circumstances.

Add references to six additional production libraries built on fiber technology.