### PR TITLE
P0876R21: make can_resume() const, add Recent WG21 History, minor cleanup

### DIFF
--- a/P0876.tex
+++ b/P0876.tex
@@ -62,11 +62,11 @@
 \begin{document}
 \small
 \begin{tabbing}
-    Document number: \= D0876R21\\
+    Document number: \= P0876R21\\
     Date:            \> 2025-06-11\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat.cognitoy@gmail.com)\\
-    Audience:        \> LWG, CWG, EWG\\
+    Audience:        \> LWG, CWG\\
 \end{tabbing}
 
 \section*{\emph{fiber\_context} - fibers without scheduler}

--- a/P0876.tex
+++ b/P0876.tex
@@ -63,7 +63,7 @@
 \small
 \begin{tabbing}
     Document number: \= P0876R21\\
-    Date:            \> 2025-06-11\\
+    Date:            \> 2025-06-23\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat.cognitoy@gmail.com)\\
     Audience:        \> LWG, CWG\\

--- a/P0876.tex
+++ b/P0876.tex
@@ -63,7 +63,7 @@
 \small
 \begin{tabbing}
     Document number: \= P0876R21\\
-    Date:            \> 2025-06-23\\
+    Date:            \> 2025-07-13\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat.cognitoy@gmail.com)\\
     Audience:        \> LWG, CWG\\
@@ -78,6 +78,7 @@
 %//////////////////////////////////////////////////////////////////////////////
 
 \input{abstract}
+\input{wg21_process}
 \input{history}
 \newpage
 \input{counter_p3620}

--- a/api.tex
+++ b/api.tex
@@ -60,7 +60,7 @@ one fiber to another is a \emph{context switch}.
 3 An \emph{implicit fiber} is the default fiber on any thread. All other
 fibers are \emph{explicit fibers.}
 
-4 An explicit fiber is created using \fiber. Instantiating \fiber \emph{prepares} a
+4 An explicit fiber is created using \fiber. Constructing a \fiber object \emph{prepares} a
 fiber, which can consume resources. A fiber can thus be in one of three
 states: prepared, running or suspended.
 

--- a/code/autocancel.cpp
+++ b/code/autocancel.cpp
@@ -25,7 +25,7 @@ private:
 // implicitly requests stop on that fiber. It uses the tactic seen in the
 // example 'filament' class to continually update the fiber_context
 // representing the fiber of interest. (See "returning synthesized
-// std::fiber_context instance from resume()")
+// std::fiber_context object from resume()")
 class autocancel{
 private:
     std::fiber_context f_;
@@ -63,7 +63,7 @@ public:
         return stop_flag_;
     }
 
-    // for initial entry from a plain fiber rather than an autocancel instance
+    // for initial entry from a plain fiber rather than an autocancel object
     std::fiber_context resume(){
         return std::move(f_).resume();
     }

--- a/code/launch.cpp
+++ b/code/launch.cpp
@@ -1,5 +1,5 @@
 // unwind_exception is an exception used internally by launch() to unwind the
-// stack of a suspended fiber when the referencing fiber_context instance is
+// stack of a suspended fiber when the referencing fiber_context object is
 // destroyed.
 class unwind_exception: public std::runtime_error {
 public:
@@ -39,7 +39,7 @@ auto launch(Fn&& entry_function) {
             }
         },
         // cancellation-function passed to fiber_context constructor
-        // throws unwind_exception, binding passed fiber_context instance.
+        // throws unwind_exception, binding passed fiber_context object.
         [](std::fiber_context&& previous)->std::fiber_context {
             throw unwind_exception{std::move(previous)};
             return {};

--- a/ecosystem.tex
+++ b/ecosystem.tex
@@ -153,14 +153,14 @@ presenting fiber-aware synchronization primitives.)
 It's true that if:
 
 \begin{itemize}
-    \item a particular function relies on a \cpp{thread\_local} variable
-    \item the function calls a function that resumes a different fiber
-    \item the other fiber makes a different call to that same function, or to
-          another function that modifies the same \cpp{thread\_local} variable
+    \item on fiber X, function F relies on a \cpp{thread\_local} variable V
+    \item function F calls function G that resumes fiber Y
+    \item fiber Y calls function F, or another function that modifies variable V
+    \item fiber Y resumes fiber X
+    \item on fiber X, function G returns to function F
 \end{itemize}
 
-then on resumption of the original fiber, the function will observe the new
-value for the \cpp{thread\_local} variable.
+then function F on fiber X will observe fiber Y's value for variable V.
 
 This is analogous to use of a \cpp{static} variable by multiple threads in the
 same program -- though not as bad, since it doesn't produce race-related
@@ -176,6 +176,14 @@ cross-thread resumption is forbidden.
 
 (This is the only optimization that has yet been surfaced by implementers as a
 potentially problematic interaction with fibers.)
+
+P3346R0\cite{P3346R0} proposed to modify \tlocal to mean fiber-specific. This
+was rejected by SG1 in Wrocław in 2024.\cite{wroclawp3346}
+
+That said, in an environment in which \tlocal referenced fiber-specific
+storage, TLS pointers cached in function stack frames would remain valid even
+if the original fiber were later resumed on some other thread, thus removing
+the restriction against cross-thread resumption.
 
 \uabschnitt{tooling} One particularly valuable consequence of adding \fiber to
 the Standard will be to add fiber awareness to debuggers, performance

--- a/ecosystem.tex
+++ b/ecosystem.tex
@@ -178,7 +178,7 @@ cross-thread resumption is forbidden.
 potentially problematic interaction with fibers.)
 
 P3346R0\cite{P3346R0} proposed to modify \tlocal to mean fiber-specific. This
-was rejected by SG1 in Wrocław in 2024.\cite{wroclawp3346}
+was rejected by SG1 in Wrocław in 2024\cite{wroclawp3346}.
 
 That said, in an environment in which \tlocal referenced fiber-specific
 storage, TLS pointers cached in function stack frames would remain valid even

--- a/exlife.tex
+++ b/exlife.tex
@@ -4,8 +4,9 @@
 In \stdclause{except.throw} paragraph 4, the destruction of an exception
 object is specified to potentially occur when an active handler for the
 exception exits, not when a handler exits while the exception is still the
-currently handled exception. It is possible to observe, with the Boost
-implementation in an Itanium C++ ABI environment, cases where an exception is
+currently handled exception. With a Boost
+implementation which predates the proposed changes to \stdclause{except}
+(in an Itanium C++ ABI environment), it is possible to observe cases where an exception is
 destroyed at a different point than specified (and, in particular, when a
 handler for the exception is still active in a fiber). Consider
 \href{https://github.com/secondlife/3p-boost/blob/nat/exstate/tests/early_exc_destroy.cpp}{the following program}.

--- a/for_examples.tex
+++ b/for_examples.tex
@@ -1,11 +1,11 @@
 \newpage
 \abschnitt{Appendix D: support code for examples}\label{autocancel}
 
-Destroying a non-empty \fiber instance invokes Undefined Behaviour
+Destroying a non-empty \fiber object invokes Undefined Behaviour
 (see \nameref{termination}). To simplify code examples in this paper, we
 introduce an \cpp{autocancel} wrapper class that launches a fiber and tracks
-the sequence of \fiber instances representing that fiber. When
-an \cpp{autocancel} instance is destroyed, it sets a stop flag and loops until
+the sequence of \fiber objects representing that fiber. When
+an \cpp{autocancel} object is destroyed, it sets a stop flag and loops until
 the fiber voluntarily terminates.
 
 \cppf{autocancel}

--- a/history.tex
+++ b/history.tex
@@ -5,10 +5,11 @@ This document supersedes P0876R20.
 
 \begin{itemize}
     \item Apply P3472R1: Make \fiber\cpp{::}\canresume \cpp{const}.
-    \item Remove ``Instantiating'' from wording. Remove remaining instances of
-          ``instance'' in front matter.
-    \item Clarify that bad behaviour in Appendices A, B and C is observed only in
+    \item Remove ``Instantiating'' from proposed wording. Remove remaining
+          instances of ``instance'' in front matter.
+    \item Clarify that bad behaviour in Appendices A and B is observed only in
           implementations predating proposed changes to \stdclause{except}.
+    \item Add ``Recent WG21 History'' section.
 \end{itemize}
 
 \uabschnitt{Changes since P0876R19}

--- a/history.tex
+++ b/history.tex
@@ -5,6 +5,10 @@ This document supersedes P0876R20.
 
 \begin{itemize}
     \item Apply P3472R1: Make \fiber\cpp{::}\canresume \cpp{const}.
+    \item Remove ``Instantiating'' from wording. Remove remaining instances of
+          ``instance'' in front matter.
+    \item Clarify that bad behaviour in Appendices A, B and C is observed only in
+          implementations predating proposed changes to \stdclause{except}.
 \end{itemize}
 
 \uabschnitt{Changes since P0876R19}
@@ -167,7 +171,7 @@ This document supersedes P0876R20.
     than ``thread of execution.''
     \item Changed ``thread'' definition to be the execution agent that runs fibers.
     \item Clarified that if a fiber terminates by returning an empty \fiber
-          instance, \cpp{std::terminate} is called.
+          object, \cpp{std::terminate} is called.
     \item Added \cpp{constexpr fiber\_context::current\_exception\_within\_fiber}.
     \item Removed definition of ``function call stack.''
     \item Removed change to definition of expression evaluation conflict.
@@ -290,7 +294,7 @@ presents a problem: how does the code that suspends a fiber find its
 associated \cpp{stop\_source} shared state?
 
 A consumer wishing to pass a \cpp{std::stop\_token} to a new fiber can itself
-instantiate \cpp{std::stop\_source}, obtain from it a \cpp{stop\_token} and
+construct a \cpp{std::stop\_source}, obtain from it a \cpp{stop\_token} and
 bind that \cpp{stop\_token} in a lambda passed to the \fiber
 constructor. Accordingly, the \fiber API need not explicitly support that.
 
@@ -360,14 +364,14 @@ a particular fiber earlier in the lifespan of the fiber, a struct serves.
 
 A more compelling reason to avoid constructing an explicit fiber with
 a \cancelfn is that no implicit fiber has any such \cancelfn\xspace -- and the
-consuming application cannot tell, a priori, whether a given \fiber instance
+consuming application cannot tell, a priori, whether a given \fiber object
 represents an explicit or an implicit fiber. If \this represents an
 implicit fiber, what should the proposed \cpp{cancel()} member function do?
 
 Passing a specific \cancelfn to \anyresumewith avoids that problem.
 
 P0876R8 follows SG1 recommendation in making it Undefined Behaviour to destroy
-(or assign to) a non-empty \fiber instance.
+(or assign to) a non-empty \fiber object.
 
 \unwindfib was reintroduced with implementation-defined behaviour to allow fiber
 cleanup leveraging implementation internals. Its use was entirely optional (and
@@ -433,7 +437,7 @@ Problems resolved by discarding \unwindex:
     \item Similarly, it was possible to catch \unwindex but not rethrow it.
     \item If we attempted to address the problem above by introducing a
           \unwindex operation to extract the bound \fiber, it became possible
-          to rethrow the exception with an empty (moved-from) \fiber instance.
+          to rethrow the exception with an empty (moved-from) \fiber object.
     \item Throwing a C++ exception during C++ exception unwinding terminates
           the program. It was possible for an exception implementation based
           on \cpp{thread\_local} to become confused by exceptions on different

--- a/implementation.tex
+++ b/implementation.tex
@@ -100,7 +100,7 @@ fiber. Using the stack as storage makes this mechanism very easy to
 implement.\footnote{The implementation of \bcontext\cite{bcontext} utilizes this
 technique.}
 Inside \resume the code pushes the relevant CPU registers onto the stack, and
-from the resulting stack address creates a new \fiber. This instance is then
+from the resulting stack address constructs a new \fiber. This object is then
 passed (or returned) into the resumed fiber (see \nameref{synthesizing}).
 
 \zs{Using the active fiber's stack as storage for the CPU state is efficient because no

--- a/invalidation.tex
+++ b/invalidation.tex
@@ -9,24 +9,24 @@ cause undefined behaviour because the stack might already be unwound (objects
 allocated on the stack were destroyed or the memory used as stack was already
 deallocated).
 
-As a consequence each call of \resume will empty the \fiber instance.
+As a consequence each call of \resume will empty the \fiber object.
 
 Whether or not a \fiber is empty can be tested with member function \opbool.
 
 To make this more explicit, functions \allresume are rvalue-reference qualified.
 %If a fiber calls \cpp{f.resume()} then the  fiber is suspended and \cpp{f} is
 %invalidated. When the fiber is resumed later, it returns from \cpp{f.resume()}
-%and instance \cpp{f} references the calling fiber (the fiber that has resumed
+%and object \cpp{f} references the calling fiber (the fiber that has resumed
 %the current fiber).
 
 The essential points:
 \begin{itemize}
     \item regardless of the number of \fiber declarations, exactly one \fiber
-          instance represents each suspended fiber
-    \item no \fiber instance represents the currently-running fiber
+          object represents each suspended fiber
+    \item no \fiber object represents the currently-running fiber
 \end{itemize}
 
-Section \nameref{solution_gpub} describes how an instance of\\
+Section \nameref{solution_gpub} describes how an object of type\\
 \fiber is synthesized from the active fiber that suspends.
 
 \zs{

--- a/low_level.tex
+++ b/low_level.tex
@@ -9,8 +9,8 @@ following frameworks are based on the low-level fiber switching API of
 \cpp{coroutine<>::push_type} and\\
 \cpp{coroutine<>::pull_type}, providing a
 unidirectional transfer of data. These stackful coroutines are only used in
-pairs. When \cpp{coroutine<>::push_type} is explicitly
-instantiated, \cpp{coroutine<>::pull_type} is synthesized and passed as
+pairs. When an object of type \cpp{coroutine<>::push_type} is explicitly
+constructed, \cpp{coroutine<>::pull_type} is synthesized and passed as
 parameter into the coroutine function. In the
 example below, \cpp{coroutine<>::push_type} (variable \cpp{writer}) provides the
 resume operation, while \cpp{coroutine<>::pull_type} (variable \cpp{in})

--- a/passing_data.tex
+++ b/passing_data.tex
@@ -10,8 +10,8 @@ new fiber. The value is incremented by one, as shown at line 4. The expression
 within the lambda by \cpp{caller}).
 
 The call to \cpp{lambda.resume()} at line 10 resumes the lambda, returning from
-the \cpp{caller.resume()} call at line 5. The \fiber instance \cpp{caller}
-emptied by the \resume call at line 5 is replaced with the new instance
+the \cpp{caller.resume()} call at line 5. The \fiber object \cpp{caller}
+emptied by the \resume call at line 5 is replaced with the new object
 returned by that same \resume call.
 
 Finally the lambda returns (the updated) \cpp{caller} at line 6, terminating its

--- a/problem_gp_ub.tex
+++ b/problem_gp_ub.tex
@@ -39,7 +39,7 @@ applicability of fibers and requires an internal global variable pointing to
 
 \uabschnitt{static member function returns active \fiber}
 P0099R0\cite{P0099R0} introduced a static member function\\
-(\cpp{execution_context::current()}) that returned an instance of the active
+(\cpp{execution_context::current()}) that returned an object representing the active
 fiber. This allows passing the active fiber \cpp{m} (for instance representing
 \main) into the fiber \cpp{f} via lambda capture. This mechanism enables
 switching back and forth between the fiber and \main, enabling a rich set of
@@ -48,12 +48,12 @@ applications (for instance generators).
 
 But this solution requires an internal global variable pointing to the active
 fiber and some kind of reference counting. Reference counting is needed because
-\cpp{fiber\_context::current()} necessarily requires multiple instances of \fiber for the
+\cpp{fiber\_context::current()} necessarily requires multiple objects of \fiber for the
 active fiber. Only when the last reference goes out of scope can the fiber be
 destroyed and its stack deallocated.
 \cppf{multi_current}
 
-Additionally a static member function returning an instance of the active fiber
+Additionally a static member function returning an object representing the active fiber
 would violate the protection requirements of sections \nameref{stackmgmt} and
 \nameref{invalidation}. For instance you could accidentally attempt to resume
 the active fiber by invoking \resume.

--- a/resume_with.tex
+++ b/resume_with.tex
@@ -12,7 +12,7 @@ called \cpp{fn()}.
 
 Like an \entryfn passed to \fiber, \cpp{fn()} must accept
 \cpp{std::fiber\_context&&} and return\\
-\fiber. The \fiber instance returned by \cpp{fn()} will, in turn, be returned
+\fiber. The \fiber object returned by \cpp{fn()} will, in turn, be returned
 to \cpp{f}'s lambda by the \resume at line 3.
 
 In the example below, suppose that code running on the program's main fiber
@@ -38,7 +38,7 @@ matters when control leaves it in either of two ways:
         a matching \cpp{catch} clause.\footnote{As stated
         in \nameref{exceptions}, if there is no matching \cpp{catch}
         clause in that fiber, \cpp{std::terminate()} is called.}
-  \item If the function returns, the returned \fiber instance is returned by
+  \item If the function returns, the returned \fiber object is returned by
         the suspended \anyresume call.
 \end{enumerate}
 
@@ -47,9 +47,9 @@ matters when control leaves it in either of two ways:
 The \cpp{f.resume\_with(<lambda>)} call at line 18 passes control to the second
 lambda on the fiber of the first lambda.
 
-As usual, \resumewith synthesizes a \fiber instance representing the calling
+As usual, \resumewith synthesizes a \fiber object representing the calling
 fiber, passed into the lambda as \cpp{m}. This particular lambda returns \cpp{m}
-unchanged at line 21; thus that \cpp{m} instance is returned by the \resume call
+unchanged at line 21; thus that object \cpp{m} is returned by the \resume call
 at line 8.
 
 Finally, the first lambda returns at line 10 the \cpp{m} variable updated at
@@ -59,10 +59,10 @@ One case worth pointing out is when you call \anyresumewith on a
 \fiber that has not yet been resumed for the first time:
 \cppfl{initial_resume_with}
 
-In this situation, \cpp{injected()} is called with a \fiber instance
+In this situation, \cpp{injected()} is called with a \fiber object
 representing the caller of \resumewith. When \cpp{injected()} eventually
-returns that (or some other) \fiber instance, the returned\\
-\fiber instance is passed into \cpp{topfunc()} as its \cpp{prev} parameter.
+returns that (or some other) \fiber object, the returned\\
+\fiber object is passed into \cpp{topfunc()} as its \cpp{prev} parameter.
 
 \zs{Member function \anyresumewith allows you to inject a
 function into a suspended fiber.}

--- a/solution_gp_ub.tex
+++ b/solution_gp_ub.tex
@@ -13,19 +13,19 @@ fiber is first started, or returned from \resume).
 
 In the pseudo-code above the fiber \cpp{f} is started by invoking its member
 function \resume at line 7. This operation suspends \cpp{foo}, empties
-instance \cpp{f} and synthesizes a new \fiber\xspace \cpp{m} that is passed as parameter
+object \cpp{f} and synthesizes a new \fiber\xspace \cpp{m} that is passed as parameter
 to the lambda of \cpp{f} (line 2).
 
 Invoking \cpp{m.resume()} (line 3) suspends the lambda, empties \cpp{m} and
 synthesizes a \fiber that is returned by \cpp{f.resume()} at line 7. The
-synthesized \fiber is assigned to \cpp{f}. Instance \cpp{f} now represents the
+synthesized \fiber is assigned to \cpp{f}. Object \cpp{f} now represents the
 suspended fiber running the lambda (suspended at line 3). Control is
 transferred from line 3 (lambda) to line 7 (\cpp{foo()}).
 
 Call \cpp{f.resume()} at line 8 empties \cpp{f} and suspends \cpp{foo()}
 again. A \fiber representing the suspended \cpp{foo()} is synthesized, returned
 from \cpp{m.resume()} and assigned to \cpp{m} at line 3. Control
-is transferred back to the lambda and instance \cpp{m} represents the suspended
+is transferred back to the lambda and object \cpp{m} represents the suspended
 \cpp{foo()}.
 
 Function \cpp{foo()} is resumed at line 4 by executing \cpp{m.resume()} so that
@@ -42,7 +42,7 @@ the current thread's \entryfn can \bfs{not} be represented by \cpp{yield\_type}
 Because \cpp{symmetric\_coroutine<>::yield\_type()} yields back to the starting
 point, i.e. invocation of\\
 \cpp{symmetric\_coroutine<>::call\_type::operator()()},
-both instances (\cpp{call\_type} as well as \cpp{yield\_type}) must be preserved.
+both objects (\cpp{call\_type} as well as \cpp{yield\_type}) must be preserved.
 Additionally the caller must be kept alive until the called coroutine terminates
 or UB happens at resumption.
 
@@ -50,7 +50,7 @@ or UB happens at resumption.
 level layer can hide that by using private variables.}
 
 \uabschnitt{representing \emph{main()} and thread's \entryfn as fiber}\label{representation}
-As shown in the previous section a synthesized instance of \fiber is passed
+As shown in the previous section a synthesized object of type \fiber is passed
 into the resumed fiber.
 
 \cppf{synthesized_main}
@@ -69,22 +69,22 @@ representing \main or a thread's \entryfn can be handled like an
 explicitly created \fiber: it can passed to and returned from functions or
 stored in a container.
 
-In the code snippet above the suspended \main is represented by instance
+In the code snippet above the suspended \main is represented by object
 \cpp{m} and could be stored in containers or managed just like \cpp{f}
 by a scheduling algorithm.
 
 \zs{The proposed fiber API allows representing and handling \main and the
-current thread's \entryfn by an instance of \fiber in the same way as
+current thread's \entryfn by an object of type \fiber in the same way as
 explicitly created fibers.}
 
 \uabschnitt{fiber returns (terminates)} When a fiber returns (terminates), what
 should happen next? Which fiber should be resumed next? The only way to avoid
 internal global variables that point to \main is to explicitly return a non-empty
-\fiber instance that will be resumed after the active fiber terminates.
+\fiber object that will be resumed after the active fiber terminates.
 \cppfl{terminating_fiber}
 
-In line 5 the fiber is started by invoking \resume on instance \cpp{f}. \main
-is suspended and an instance of type \fiber is synthesized and passed as
+In line 5 the fiber is started by invoking \resume on object \cpp{f}. \main
+is suspended and an object of type \fiber is synthesized and passed as
 parameter \cpp{m} to the lambda at line 2. The fiber terminates by returning
 \cpp{m}. Control is transferred to \main (returning from \cpp{f.resume()} at
 line 5) while fiber \cpp{f} is destroyed.
@@ -100,7 +100,7 @@ This is necessary in order to prevent destructing \cpp{f} when the lambda
 returns. Fiber \cpp{f2} uses \cpp{f1}, that was also captured by the lambda, as
 return value. Fiber \cpp{f2} terminates while fiber \cpp{f1} is resumed (entered
 the first time). The synthesized \fiber\xspace \cpp{f} passed into the lambda at line 3
-represents the terminated fiber \cpp{f2} (e.g. the calling fiber). Thus instance
+represents the terminated fiber \cpp{f2} (e.g. the calling fiber). Thus object
 \cpp{f} is empty as the assert statement verifies at line 5. Fiber \cpp{f1} uses
 the captured \fiber\xspace \cpp{m} as return value (line 6). Control is returned to
 \main, returning from \cpp{f2.resume()} at line 13.
@@ -109,10 +109,10 @@ the captured \fiber\xspace \cpp{m} as return value (line 6). Control is returned
 signature `\cpp{fiber\_context(fiber\_context&&)}`. Using \fiber as the return
 value from such a function avoids global variables.}
 
-\uabschnitt{returning synthesized \fiber instance from \cpp{resume()}}\label{fiberreturn}
-An instance of \fiber remains empty after return from \anyresume: the
+\uabschnitt{returning synthesized \fiber object from \cpp{resume()}}\label{fiberreturn}
+An object of type \fiber remains empty after return from \anyresume: the
 synthesized fiber is returned, instead of implicitly updating the \fiber
-instance on which \resume was called.
+object on which \resume was called.
 
 If the \fiber object were implicitly updated, the fiber would 
 change its identity because each fiber is associated with a stack. Each stack
@@ -135,7 +135,7 @@ The for-loop prints the name \emph{f1} and resumes fiber \cpp{f2}. Inside
 resumes fiber \cpp{f1} at line 7. Inside \cpp{f1} control returns from
 \cpp{f2.resume()}. \cpp{f1} loops, prints out the name and invokes \cpp{f2.resume()}. But
 this time fiber \cpp{f3} instead of \cpp{f2} is resumed. This is caused by the
-fact the instance \cpp{f2} gets the synthesized \fiber of \cpp{f3} implicitly
+fact that the object \cpp{f2} gets the synthesized \fiber of \cpp{f3} implicitly
 assigned. Remember that at line 7 fiber \cpp{f3} gets suspended while \cpp{f1}
 is resumed through \cpp{f1.resume()}.
 
@@ -143,7 +143,7 @@ This problem can be solved by returning the synthesized \fiber from \anyresume.
 \cppf{return_from_resume_invalid}
 
 In the example above the synthesized \fiber returned by each \resume call is
-specifically move-assigned to a \fiber instance other than the one on which \resume
+specifically move-assigned to a \fiber object other than the one on which \resume
 was called, to properly track the three fibers. (Of course this particular example
 depends on static knowledge of the overall control flow. But the API does not, in
 general, require that.)
@@ -154,15 +154,15 @@ in order to prevent changing the identity of the fiber.}
 
 If the overall control flow isn't known, member function \anyresumewith
 (see section \nameref{resumewith}) can be used to assign the
-synthesized \fiber to the correct \fiber instance (held by the caller).
+synthesized \fiber to the correct \fiber object (held by the caller).
 \cppf{assign_resumewith}
 
 Picture a higher-level framework in which every fiber can find its associated
-\cpp{filament} instance, as well as others. Every context switch must be mediated by
-passing \emph{the target} \cpp{filament} instance to \emph{the running fiber's}
+\cpp{filament} object, as well as others. Every context switch must be mediated by
+passing \emph{the target} \cpp{filament} object to \emph{the running fiber's}
 \cpp{resume\_next()}.
 
-Running fiber A has an associated \cpp{filament} instance \cpp{filamentA},
+Running fiber A has an associated \cpp{filament} object \cpp{filamentA},
 whose \fiber\xspace\cpp{filament::f\_} is empty -- because fiber A is running.
 
 Desiring to switch to suspended fiber B (with associated
@@ -173,21 +173,21 @@ Desiring to switch to suspended fiber B (with associated
 This empties \cpp{filamentB.f\_} -- because fiber B is now running.
 
 The lambda binds \cpp{&filamentA} as \cpp{this}. Running on fiber B, it
-receives a \fiber instance representing the newly-suspended fiber A as its
-parameter \cpp{f}. It moves that \fiber instance to \cpp{filamentA.f\_}.
+receives a \fiber object representing the newly-suspended fiber A as its
+parameter \cpp{f}. It moves that \fiber object to \cpp{filamentA.f\_}.
 
 The lambda then returns a default-constructed (therefore empty) \fiber
-instance. That empty instance is returned by the previously-suspended
+object. That empty object is returned by the previously-suspended
 \resumewith call in \cpp{filamentB.resume\_next()} -- which is fine because
 \cpp{resume\_next()} drops it on the floor anyway.
 
 Thus, the running fiber's associated \cpp{filament::f\_} is always empty,
 whereas the \cpp{filament} associated with each suspended fiber is continually
-updated with the \fiber instance representing that
+updated with the \fiber object representing that
 fiber.\footnote{\bfiber\cite{bfiber} uses this pattern for resuming user-land
 threads.}
 
 \zs{It is not necessary to know the overall control flow. It is sufficient to
 pass a reference/pointer of the \emph{caller} (fiber that gets suspended) to the
 resumed fiber that move-assigns the synthesized \fiber to \emph{caller} (updating
-the instance).}
+the object).}

--- a/stack.tex
+++ b/stack.tex
@@ -2,15 +2,15 @@
 
 On construction of a \fiber a stack is allocated. When the \entryfn returns,
 the stack will be destroyed. If the function has not yet returned,
-the \fiber instance representing that fiber must not be destroyed.
+the \fiber object representing that fiber must not be destroyed.
 %% and the
-%% destructor of the \fiber instance representing that context is called,
+%% destructor of the \fiber object representing that context is called,
 %% the stack will be unwound and destroyed.
 %% the calling program is responsible for unwinding the stack.
 
 %%The fiber's \cancelfn is used to trigger cleanup.
 %%
-%%Consider a running fiber \cpp{f2} that destroys the \fiber instance
+%%Consider a running fiber \cpp{f2} that destroys the \fiber object
 %%representing \cpp{f1}.
 %%
 %%\cpp{f1}'s destructor, running on \cpp{f2}, implicitly calls member-function
@@ -22,10 +22,10 @@ the \fiber instance representing that fiber must not be destroyed.
 %%might throw an exception. It might set a distinguished value in some object
 %%tested by code on \cpp{f1}. In any case, fiber \cpp{f2} remains suspended
 %%in \cpp{f1}'s destructor until \cpp{f1}'s \entryfn returns (the \fiber
-%%instance synthesized for) \cpp{f2} -- or until \cpp{f2} is explicitly resumed
+%%object synthesized for) \cpp{f2} -- or until \cpp{f2} is explicitly resumed
 %%in some other way.
 
-%% Function \unwindfib caches an instance of \fiber that
+%% Function \unwindfib caches an object of type \fiber that
 %% represents \cpp{f2}, then unwinds \cpp{f1}'s stack
 %% (walking the stack and destroying automatic variables in reverse order of
 %% construction).

--- a/termination.tex
+++ b/termination.tex
@@ -3,7 +3,7 @@
 %% There are a few different ways to terminate a given fiber without
 %% terminating the whole process, or engaging undefined behaviour.
 %% 
-%% When a \fiber instance is constructed with an \entryfn, its new stack is
+%% When a \fiber object is constructed with an \entryfn, its new stack is
 %% initialized with the frame of an implicit top-level function that marks the
 %% end of the stack. \unwindfib unwinds the stack back to
 %% that top-level function, which resumes the \fiber passed to \unwindfib.
@@ -19,10 +19,10 @@
 %%           does. Since\\\unwindfib accepts a \fiber, and since \resumewith
 %%           synthesizes a\\\fiber representing its caller and passes it to the
 %%           subject function, this terminates the fiber referenced by the
-%%           original \fiber instance and then resumes the caller.
+%%           original \fiber object and then resumes the caller.
 %%     \item Engage \dtor: switch to some other fiber, which will
-%%           receive a \fiber instance representing the current fiber. Make that
-%%           other fiber destroy the received \fiber instance.
+%%           receive a \fiber object representing the current fiber. Make that
+%%           other fiber destroy the received \fiber object.
 %% \end{itemize}
 %% 
 %% The above are all equivalent: stack variables are properly destroyed, since
@@ -33,19 +33,19 @@ Every \fiber you launch must
 terminate gracefully by returning from its \entryfn.
 %% You may not
 %% call \unwindfib. You may not call \dtor, explicitly or implicitly, on a
-%% non-empty \fiber instance. With these restrictions, it is possible to use
+%% non-empty \fiber object. With these restrictions, it is possible to use
 %% the \fiber facility without exception support.
 
 When an explicitly-launched fiber's \entryfn returns a non-empty \fiber
-instance, the running fiber is terminated. Control switches to the fiber
-indicated by the returned \fiber instance. The \entryfn may return (switch to)
-any reachable non-empty \fiber instance -- it need not be the instance originally
-passed in, or an instance returned from the \resume family of methods.
+object, the running fiber is terminated. Control switches to the fiber
+represented by the returned \fiber object. The \entryfn may return (switch to)
+any reachable non-empty \fiber object -- it need not be the object originally
+passed in, or an object returned from the \resume family of methods.
 
-\emph{Calling} \resume means: ``Please switch to the indicated fiber; I
+\emph{Calling} \resume means: ``Please switch to the specified fiber; I
 am suspending; please resume me later.''
 
-\emph{Returning} a particular \fiber means: ``Please switch to the indicated
+\emph{Returning} a particular \fiber means: ``Please switch to the specified
 fiber; and by the way, I am done.''
 
 Cancellation of another fiber is not explicitly supported
@@ -61,10 +61,10 @@ might not immediately return.
 One tactic would be to request termination, then loop over \anyresume calls until
 the returned \fiber is \emptyfn. However, that information is ambiguous.
 
-Suppose we have a \fiber instance \cpp{f1} representing suspended fiber F,
+Suppose we have a \fiber object \cpp{f1} representing suspended fiber F,
 with an application-specific termination request mechanism. The running fiber
 M requests F to terminate, then calls \cpp{f1.resume()}, which in due course
-returns another \fiber instance \cpp{f2}.
+returns another \fiber object \cpp{f2}.
 
 \cpp{f2} has various possible values.
 
@@ -92,7 +92,7 @@ possible cancellation implementation, subject to the limitations described
 above.
 
 %% The \emph{last} fiber on a particular thread has no non-empty \fiber to
-%% return. For this reason, returning an empty \fiber instance (\opbool
+%% return. For this reason, returning an empty \fiber object (\opbool
 %% returns \false) terminates the calling thread. This is true whether or
 %% not the thread's default fiber (see \nameref{fiber-context.general}) has
 %% terminated.
@@ -195,9 +195,9 @@ above.
 %% it is worth pointing out that destroying a non-empty \fiber on a thread other
 %% than the thread on which it was last resumed will run those object destructors
 %% %% and \catchall clauses
-%% on the thread destroying the \fiber instance.
+%% on the thread destroying the \fiber object.
 %% 
-%% As a consequence, destroying a \fiber instance representing a thread's default
+%% As a consequence, destroying a \fiber object representing a thread's default
 %% fiber (see \nameref{fiber-context.general})
 %% from any other thread engages Undefined Behaviour.\footnote{One unobvious case
 %% would be if a fiber running on non-\main thread \cpp{T} stores a \fiber
@@ -228,9 +228,9 @@ above.
 %% as long as desired.
 %% 
 %% Ultimately, however, it must be possible to exit a fiber in such as way as to
-%% terminate the calling thread. Returning an empty \fiber instance from
+%% terminate the calling thread. Returning an empty \fiber object from
 %% a fiber's \entryfn terminates the running thread. Consequently, passing an
-%% empty \fiber instance to \unwindfib also terminates the calling thread.
+%% empty \fiber object to \unwindfib also terminates the calling thread.
 %% 
 %% The \fiber facility does not defend against the case in which a thread's
 %% default fiber suspends (rather than terminating), but the explicit fiber it
@@ -238,5 +238,5 @@ above.
 %% above. A higher-level library built on \fiber can provide a scheduler.
 %% The \fiber facility intentionally does not.
 %% 
-%% The conceptual top-level function above \main, given an empty \fiber instance to resume,
+%% The conceptual top-level function above \main, given an empty \fiber object to resume,
 %% terminates the whole process instead of that one thread.

--- a/throw.tex
+++ b/throw.tex
@@ -22,7 +22,8 @@ which the \nt{stmt.block}{compound-statement} or
 \nt{class.base.init}{ctor-initializer} following the \cpp{try} keyword was
 most recently entered by the thread of control and not yet exited.''
 
-In any case, if ``currently handled exception'' means the exception with the
+This is the reason for the proposed changes to \stdclause{except}.
+If ``currently handled exception'' means the exception with the
 most recently activated handler within any fiber on the current thread, we can get
 \href{https://github.com/secondlife/3p-boost/blob/nat/exstate/tests/nullary_throw.cpp}{the following result}.
 

--- a/tls.tex
+++ b/tls.tex
@@ -2,7 +2,7 @@
 
 Any thread in a program may be shared by multiple fibers.
 
-A newly-instantiated fiber is not yet associated with any thread. However,
+A newly-constructed fiber is not yet associated with any thread. However,
 once a fiber has been resumed the first time by some thread, it must
 thereafter be resumed only by that same thread.
 

--- a/wg21_process.tex
+++ b/wg21_process.tex
@@ -1,0 +1,62 @@
+\abschnitt{Recent WG21 History}\label{wg21_history}
+
+In St. Louis in June 2024,
+\href{https://docs.google.com/document/d/1ebdFai3h2Y4g5NayNf_pG6Gl2qidYdF6G-smMWNw-Go/edit?tab=t.0#heading=h.9aqgmrf0hvh1}{LWG tentatively approved}
+P0876 Library wording.
+
+In Tokyo in March 2024, CWG finished initial P0876 Core wording review, with
+\href{https://wiki.edg.com/bin/view/Wg21tokyo2024/CoreWorkingGroup#D0876R16_fiber_context}{one requested change}:
+that P0876 mandate per-fiber exception state. That required EWG approval.
+
+In St. Louis in June 2024,
+\href{https://wiki.edg.com/bin/view/Wg21stlouis2024/NotesEWGP0876}{EWG approved} the change:
+
+\begin{table}[ht]
+\begin{tabular}{|r|r|r|r|r|} % right-just columns (5 columns)
+\hline %inserts horizontal line
+SF & F & N & A & SA \\ [0.5ex] % inserts table heading
+\hline % inserts single horizontal line
+6 & 8 & 3 & 0 & 0 \\ % [1ex] % [1ex] adds vertical space
+\hline %inserts single line
+\end{tabular}
+\end{table}
+
+However, EWG did not forward P0876 back to CWG, requesting implementation
+experience with the proposed change.
+
+In Wrocław in November 2024, Nat Goodspeed presented implementation experience
+with libstdc++.
+\href{https://wiki.edg.com/bin/view/Wg21wroclaw2024/NotesEWGP0876}{Microsoft requested}
+time to consult the backend team. EWG agreed to defer to Hagenberg.
+
+In Hagenberg in February 2025, late in the week,
+\href{https://lists.isocpp.org/ext/2025/02/25138.php}{Microsoft conceded} that
+per-fiber exception state is implementable with the MSVC runtime (while voicing
+performance concerns). Unfortunately this response arrived so late that EWG
+ran out of time without considering P0876.
+
+In Sofia in June 2025,
+\href{https://docs.google.com/document/d/1wItX212LurEjkJK53XxnxumciqTRzxTSTJ48GwFihpE/edit?tab=t.0#heading=h.zc6lxwkrnobj}{EWG forwarded P0876}
+back to CWG and LWG for inclusion in C++26:
+
+\begin{table}[ht]
+\begin{tabular}{|r|r|r|r|r|} % right-just columns (5 columns)
+\hline %inserts horizontal line
+SF & F & N & A & SA \\ [0.5ex] % inserts table heading
+\hline % inserts single horizontal line
+10 & 14 & 4 & 5 & 1 \\ % [1ex] % [1ex] adds vertical space
+\hline %inserts single line
+\end{tabular}
+\end{table}
+
+But both CWG and LWG ran out of time in Sofia without considering P0876,
+thereby postponing it to C++29.
+
+Concerning a <feature> that fails to make the deadline for C++<NN>,
+\href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1000r6.pdf}{P1000R6}
+says:
+``Just wait a couple more meetings and C++<NN+3> will be open for business and <feature> can be
+the first thing voted into the C++<NN+3> working draft.''
+
+This is the promise of the train model. It matters to all of us that the train
+model works as promised.

--- a/wg21_process.tex
+++ b/wg21_process.tex
@@ -55,8 +55,10 @@ thereby postponing it to C++29.
 Concerning a <feature> that fails to make the deadline for C++<NN>,
 \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1000r6.pdf}{P1000R6}
 says:
-``Just wait a couple more meetings and C++<NN+3> will be open for business and <feature> can be
-the first thing voted into the C++<NN+3> working draft.''
+\begin{quote}
+Just wait a couple more meetings and C++<NN+3> will be open for business and <feature> can be
+the first thing voted into the C++<NN+3> working draft.
+\end{quote}
 
 This is the promise of the train model. It matters to all of us that the train
 model works as promised.


### PR DESCRIPTION
The majority of the changes here are to remove use of the term "instance" when referring to an object of type fiber_context. Jens Maurer told me that the Standard doesn't use the word "instance" to mean a class object, since "instance" is also used for template instantiation. Only one instance of "Instantiating" was in our proposed wording. Nonetheless, to avoid potential CWG objections, I've purged that use of that term from the rest of the proposal too.