### PR TITLE
Reference P4003, P4007 about networking and async I/O

### DIFF
--- a/P0876.tex
+++ b/P0876.tex
@@ -63,7 +63,7 @@
 \small
 \begin{tabbing}
     Document number: \= P0876R22\\
-    Date:            \> 2025-07-13\\
+    Date:            \> 2025-11-04\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat.cognitoy@gmail.com)\\
     Audience:        \> LWG, CWG\\

--- a/P0876.tex
+++ b/P0876.tex
@@ -63,10 +63,10 @@
 \small
 \begin{tabbing}
     Document number: \= P0876R22\\
-    Date:            \> 2025-11-04\\
+    Date:            \> 2026-02-22\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat.cognitoy@gmail.com)\\
-    Audience:        \> LWG, CWG\\
+    Audience:        \> LEWG, LWG, CWG\\
 \end{tabbing}
 
 \section*{\emph{fiber\_context} - fibers without scheduler}
@@ -81,6 +81,7 @@
 \input{wg21_process}
 \input{history}
 \newpage
+\input{network}
 \input{counter_p3620}
 \input{ecosystem}
 \input{control_transfer}

--- a/P0876.tex
+++ b/P0876.tex
@@ -62,7 +62,7 @@
 \begin{document}
 \small
 \begin{tabbing}
-    Document number: \= P0876R21\\
+    Document number: \= P0876R22\\
     Date:            \> 2025-07-13\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat.cognitoy@gmail.com)\\

--- a/abstract.tex
+++ b/abstract.tex
@@ -8,7 +8,7 @@ constructs such as stackful coroutines as well as cooperative multitasking
 
 This revision addresses concerns, questions and suggestions from the past meetings.
 The proposed API supersedes the former proposals N3985\cite{N3985},
-P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3} and P0876R20\cite{P0876R20}.
+P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3} and P0876R21\cite{P0876R21}.
 
 Because of name clashes with \emph{coroutine} from C++20,
 \emph{execution context} from executor proposals and \emph{continuation} used

--- a/api.tex
+++ b/api.tex
@@ -1,14 +1,14 @@
 \newpage
 \abschnitt{Wording}\label{api}
 
-This wording is relative to N5014.\cite{Standard}
+This wording is relative to N5032.\cite{Standard}
 
 \zs{Append to \stdsection{3.6}{defns.block} as indicated:}
 
 \add{\tsnoten{1 to entry}{Unless stated otherwise, blocking blocks the current
 thread.}}
 
-\zs{Modify \stdsection{4.1.2}{intro.abstract} paragraph 7.3 as indicated:}
+\zs{Modify \stdsection{4.1.2}{intro.abstract} paragraph 8.3 as indicated:}
 
 \begin{description}
     \item[---] The input and output dynamics of interactive devices shall take
@@ -75,8 +75,8 @@ undefined.}
 
 When an exception is thrown, control is transferred to the nearest handler
 with a matching type \xref{except.handle}; ``nearest'' means the handler for
-which the \nt{stmt.block}{compound-statement} or
-\nt{class.base.init}{ctor-initializer} following the \cpp{try} keyword was
+which the \nt{compound-statement}{stmt.block} or
+\nt{ctor-initializer}{class.base.init} following the \cpp{try} keyword was
 most recently entered by the \replace{thread of control}{running fiber} and
 not yet exited.
 
@@ -94,7 +94,7 @@ matching handler continues in a dynamically surrounding try block of the same
 
 \zs{Modify \stdsection{14.4}{except.handle} paragraph 10 as indicated:}
 
-8 The exception with the most recently activated handler
+10 The exception with the most recently activated handler
 \add{in the running fiber ([intro.fibers])} that is still active is called the
 \emph{currently handled exception}.
 
@@ -102,6 +102,11 @@ matching handler continues in a dynamically surrounding try block of the same
 
 The function \stdterm{\cpp{std::uncaught\_exceptions}}{uncaught.exceptions}
 returns the number of uncaught exceptions in the
+\replace{current thread}{running fiber ([intro.fibers])}.
+
+\zs{Modify \stdsection{17.9.6}{uncaught.exceptions} paragraph 1 as indicated:}
+
+1 \emph{Returns:} The number of uncaught exceptions \xref{except.throw} in the
 \replace{current thread}{running fiber ([intro.fibers])}.
 
 \zs{Insert new final subclause in clause 32 \stdclause{thread} as indicated:}

--- a/api.tex
+++ b/api.tex
@@ -1,7 +1,7 @@
 \newpage
 \abschnitt{Wording}\label{api}
 
-This wording is relative to N4981.\cite{Standard}
+This wording is relative to N5014.\cite{Standard}
 
 \zs{Append to \stdsection{3.6}{defns.block} as indicated:}
 
@@ -18,7 +18,7 @@ thread.}}
                implementation-defined.
 \end{description}
 
-\zs{Modify \stdsection{6.9.2.1}{intro.multithread.general} paragraph 1 as indicated:}
+\zs{Modify \stdsection{6.10.2.1}{intro.multithread.general} paragraph 1 as indicated:}
 
 A \emph{thread of execution} (also known as a \emph{thread}) is
 \replace{a single flow of control}{the primary execution agent}\\
@@ -32,10 +32,10 @@ execution steps}.
 
 \add{When a thread is created, it runs a default fiber ([intro.fibers]).}
 
-\zs{Insert before \stdsection{6.9.3}{basic.start} and renumber existing 6.9.3 to 6.9.4:}
+\zs{Insert before \stdsection{6.10.3}{basic.start} and renumber existing 6.10.3 to 6.10.4:}
 
 \setcounter{section}{6}
-\setcounter{subsection}{9}
+\setcounter{subsection}{10}
 \setcounter{subsubsection}{2}
 \setcounter{secnumdepth}{4}
 \cbstart
@@ -92,21 +92,21 @@ If no match is found among the handlers for a try block, the search for a
 matching handler continues in a dynamically surrounding try block of the same
 \replace{thread}{fiber}.
 
-\zs{Modify \stdsection{14.4}{except.handle} paragraph 8 as indicated:}
+\zs{Modify \stdsection{14.4}{except.handle} paragraph 10 as indicated:}
 
 8 The exception with the most recently activated handler
 \add{in the running fiber ([intro.fibers])} that is still active is called the
 \emph{currently handled exception}.
 
-\zs{Modify \stdsection{14.6.3}{except.uncaught} paragraph 1 as indicated:}
+\zs{Modify \stdsection{14.2}{except.throw} paragraph 7 Note 5 as indicated:}
 
-... The function \stdterm{\cpp{std::uncaught\_exceptions}}{uncaught.exceptions}
+The function \stdterm{\cpp{std::uncaught\_exceptions}}{uncaught.exceptions}
 returns the number of uncaught exceptions in the
 \replace{current thread}{running fiber ([intro.fibers])}.
 
-\zs{Insert new final subclause in clause 33 \stdclause{thread} as indicated:}
+\zs{Insert new final subclause in clause 32 \stdclause{thread} as indicated:}
 
-\setcounter{section}{33}
+\setcounter{section}{32}
 \setcounter{subsection}{11}
 \setcounter{secnumdepth}{4}
 

--- a/commands.tex
+++ b/commands.tex
@@ -85,7 +85,7 @@
 \newcommand{\add}[1]{\green{#1}}
 \newcommand{\replace}[2]{\delete{#1}\add{#2}}
 \newcommand{\eel}[2]{\href{https://eel.is/c++draft/#1}{#2}}
-\newcommand{\nt}[2]{\eel{#1\#nt:#2}{\emph{#2}}}
+\newcommand{\nt}[2]{\eel{#2\#nt:#1}{\emph{#1}}}
 \newcommand{\stdclause}[1]{\eel{#1}{[#1]}}                          
 \newcommand{\xref}[1]{(\stdclause{#1})}
 \newcommand{\stdterm}[2]{#1\xspace\xref{#2}}

--- a/history.tex
+++ b/history.tex
@@ -1,5 +1,7 @@
 \abschnitt{Revision History}\label{history}
-This document supersedes P0876R20.
+This document supersedes P0876R21.
+
+\uabschnitt{Changes since P0876R21}
 
 \uabschnitt{Changes since P0876R20}
 

--- a/history.tex
+++ b/history.tex
@@ -3,6 +3,10 @@ This document supersedes P0876R21.
 
 \uabschnitt{Changes since P0876R21}
 
+\begin{itemize}
+    \item Update to reference N5014.
+\end{itemize}
+
 \uabschnitt{Changes since P0876R20}
 
 \begin{itemize}

--- a/history.tex
+++ b/history.tex
@@ -5,6 +5,7 @@ This document supersedes P0876R21.
 
 \begin{itemize}
     \item Update to reference N5032.
+    \item Reference recent network-related papers.
 \end{itemize}
 
 \uabschnitt{Changes since P0876R20}

--- a/history.tex
+++ b/history.tex
@@ -4,7 +4,7 @@ This document supersedes P0876R21.
 \uabschnitt{Changes since P0876R21}
 
 \begin{itemize}
-    \item Update to reference N5014.
+    \item Update to reference N5032.
 \end{itemize}
 
 \uabschnitt{Changes since P0876R20}

--- a/network.tex
+++ b/network.tex
@@ -1,0 +1,31 @@
+\abschnitt{P4003R0, P4007R0: Coroutines and network I/O}
+
+%\uabschnitt{}
+
+P4003R0\cite{P4003R0} points out the performance cost of using the default
+coroutine frame allocator for asynchronous network I/O. A very important
+characteristic of network I/O, or asynchronous I/O in general, is that the
+lifespan of an I/O operation cannot be bounded by its calling coroutine.
+Therefore the compiler cannot apply HALO optimization to elide the coroutine
+frame for any coroutine in the call chain: the frame for every caller must be
+allocated dynamically.
+
+P4003R0 suggests a special recycling frame allocator which must be
+propagated through the call chain. The recommended approach is to cache a
+pointer to the allocator in \cpp{thread\_local} storage.
+
+Asynchronous I/O using fiber suspension, rather than C++20 coroutine
+suspension, bypasses this allocator question. The memory pool for function
+frame allocation is continuously referenced by the processor stack pointer
+register. A new frame is allocated by decrementing that register, released by
+incrementing it. Without HALO, it would be difficult for C++20 coroutine frame
+allocation to use fewer instructions.
+
+P4007R0\cite{P4007R0} further points out that coroutines waiting on
+Sender/Receiver asynchronous operations can only leverage a special coroutine
+frame allocator by explicitly passing that allocator through every coroutine
+parameter list in the call chain.
+
+Again, using fiber suspension rather than C++20 coroutine suspension would
+delegate the whole problem of function frame allocation to the normal C++
+runtime.

--- a/network.tex
+++ b/network.tex
@@ -10,9 +10,11 @@ Therefore the compiler cannot apply HALO optimization to elide the coroutine
 frame for any coroutine in the call chain: the frame for every caller must be
 allocated dynamically.
 
-P4003R0 suggests a special recycling frame allocator which must be
-propagated through the call chain. The recommended approach is to cache a
-pointer to the allocator in \cpp{thread\_local} storage.
+P4003R0 suggests a special recycling frame allocator which must be propagated
+through the call chain. To avoid signature pollution, the allocator is
+retained in the coroutine frame's environment and delivered to child
+coroutines via a \cpp{thread\_local} write-through cache during
+\cpp{operator new}.
 
 Asynchronous I/O using fiber suspension, rather than C++20 coroutine
 suspension, bypasses this allocator question. The memory pool for function

--- a/references.tex
+++ b/references.tex
@@ -33,8 +33,8 @@
         {N3985: A proposal to add coroutines to the C++ standard library}
 
     \bibitem{Standard}
-        \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/n4981.pdf}
-        {N4981: Working Draft, Programming Languages -- C++}
+        \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/n5014.pdf}
+        {N5014: Working Draft, Programming Languages -- C++}
 
     \bibitem{P0099R0}
         \href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0099r0.pdf}

--- a/references.tex
+++ b/references.tex
@@ -165,6 +165,14 @@
         \href{https://isocpp.org/files/papers/P3620R0.pdf}
         {P3620R0: Concerns with the proposed addition of fibers to C++26}
 
+    \bibitem{P4003R0}
+        \href{https://wg21.link/p4003}
+        {P4003R0: Coroutines for I/O}
+
+    \bibitem{P4007R0}
+        \href{https://wg21.link/p4007}
+        {P4007R0: Senders and Coroutines}
+
     \bibitem{coreguidlines}
         \href{http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Ri-global}
         {C++ Core Guidelines}

--- a/references.tex
+++ b/references.tex
@@ -33,8 +33,8 @@
         {N3985: A proposal to add coroutines to the C++ standard library}
 
     \bibitem{Standard}
-        \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/n5014.pdf}
-        {N5014: Working Draft, Programming Languages -- C++}
+        \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/n5032.pdf}
+        {N5032: Working Draft, Programming Languages -- C++}
 
     \bibitem{P0099R0}
         \href{http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0099r0.pdf}

--- a/references.tex
+++ b/references.tex
@@ -137,6 +137,10 @@
         \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p0876r20.pdf}
         {P0876R20: fibers without scheduler}
 
+    \bibitem{P0876R21}
+        \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p0876r21.pdf}
+        {P0876R21: fibers without scheduler}
+
     \bibitem{P1677R2}
         \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1677r2.pdf}
         {P1677R2: Cancellation is serendipitous-success}

--- a/throw.tex
+++ b/throw.tex
@@ -2,8 +2,8 @@
 \abschnitt{Appendix B: throw-expression with no operand}\label{throw}
 
 Both \stdclause{expr.throw} paragraph 3 and \cpp{current\_exception()}
-(\stdclause{propagation} paragraph 8) reference the ``currently handled
-exception'' (\stdclause{except.handle} paragraph 8). Thus, the
+(\stdclause{propagation} paragraph 9) reference the ``currently handled
+exception'' (\stdclause{except.handle} paragraph 10). Thus, the
 construct \cpp{throw;} is by definition equivalent to\\
 \cpp{std::rethrow\_exception(std::current\_exception());}
 (\stdclause{propagation} paragraph 9).
@@ -18,8 +18,8 @@ must be inferred from \stdclause{except.throw} paragraph 2:
 
 ``When an exception is thrown, control is transferred to the nearest handler
 with a matching type \xref{except.handle}; ``nearest'' means the handler for
-which the \nt{stmt.block}{compound-statement} or
-\nt{class.base.init}{ctor-initializer} following the \cpp{try} keyword was
+which the \nt{compound-statement}{stmt.block} or
+\nt{ctor-initializer}{class.base.init} following the \cpp{try} keyword was
 most recently entered by the thread of control and not yet exited.''
 
 This is the reason for the proposed changes to \stdclause{except}.

--- a/wg21_process.tex
+++ b/wg21_process.tex
@@ -1,8 +1,20 @@
 \abschnitt{Recent WG21 History}\label{wg21_history}
 
+In Kona in November
+2023, \href{https://wiki.edg.com/bin/view/Wg21kona2023/P0876-20231108}{LWG
+asked} whether \canresume could be \cpp{const}.
+
 In St. Louis in June 2024,
 \href{https://docs.google.com/document/d/1ebdFai3h2Y4g5NayNf_pG6Gl2qidYdF6G-smMWNw-Go/edit?tab=t.0#heading=h.9aqgmrf0hvh1}{LWG tentatively approved}
 P0876 Library wording.
+
+In January 2025, Andrzej Krzemieński
+posted \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3472r1.html}{P3472R1}
+requesting that change to \canresume. The authors accepted this as a friendly amendment, incorporating it
+into \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p0876r21.pdf}{P0876R21}.
+But this change necessitated another detour through LEWG to approve. As of the
+November 2025 meeting in Kona, LEWG declined to consider P0876R21 due to the
+large queue of NB comments.
 
 In Tokyo in March 2024, CWG finished initial P0876 Core wording review, with
 \href{https://wiki.edg.com/bin/view/Wg21tokyo2024/CoreWorkingGroup#D0876R16_fiber_context}{one requested change}:


### PR DESCRIPTION
[P4003](https://github.com/cppalliance/wg21-papers/blob/master/source/d4003-coroutine-io.md) discusses using C++20 coroutines, rather than the Sender/Receiver model, for managing asynchronous network I/O.

[P4007](https://github.com/cppalliance/wg21-papers/blob/master/source/d4007-senders-and-coros.md) addresses problems with interfacing C++20 coroutines with Sender/Receiver operations, notably (for our purposes) the timing issue with coroutine frame allocation. A coroutine participating in Sender/Receiver cannot access the allocator associated with the operation until *after* its frame has been allocated.

Neither paper has yet been published: both are expected to be submitted for the Croydon 2026-03 mailing.

Both point out the same C++20 coroutine difficulty, that could be bypassed by using fiber suspension rather than coroutine suspension to manage async. Please review the new section addressing this.

I've updated the Standard's section numbers et al. to reference the most recent published Working Draft N5032. To help me review the relevant passages, I used an editor macro to trawl through embedded references to the Standard's stable names. That made it expedient to swap the arguments to the \\nt LaTeX command, to make it consistent with the other two-argument commands referencing stable names.

I added LEWG to the distribution list because the LWG co-chair pointed out that LEWG must approve the change to make fiber_context::can_resume() const.