### PR TITLE
Update recent WG21 history section.

### DIFF
--- a/P0876.tex
+++ b/P0876.tex
@@ -62,7 +62,7 @@
 \begin{document}
 \small
 \begin{tabbing}
-    Document number: \= P0876R22\\
+    Document number: \= P0876R23\\
     Date:            \> 2026-02-22\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat.cognitoy@gmail.com)\\

--- a/P0876.tex
+++ b/P0876.tex
@@ -63,10 +63,10 @@
 \small
 \begin{tabbing}
     Document number: \= P0876R23\\
-    Date:            \> 2026-02-22\\
+    Date:            \> 2026-05-11\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat.cognitoy@gmail.com)\\
-    Audience:        \> LEWG, LWG, CWG\\
+    Audience:        \> LWG, CWG\\
 \end{tabbing}
 
 \section*{\emph{fiber\_context} - fibers without scheduler}

--- a/abstract.tex
+++ b/abstract.tex
@@ -8,7 +8,7 @@ constructs such as stackful coroutines as well as cooperative multitasking
 
 This revision addresses concerns, questions and suggestions from the past meetings.
 The proposed API supersedes the former proposals N3985\cite{N3985},
-P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3} and P0876R21\cite{P0876R21}.
+P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3} and P0876R22\cite{P0876R22}.
 
 Because of name clashes with \emph{coroutine} from C++20,
 \emph{execution context} from executor proposals and \emph{continuation} used

--- a/history.tex
+++ b/history.tex
@@ -1,5 +1,7 @@
 \abschnitt{Revision History}\label{history}
-This document supersedes P0876R21.
+This document supersedes P0876R22.
+
+\uabschnitt{Changes since P0876R22}
 
 \uabschnitt{Changes since P0876R21}
 

--- a/history.tex
+++ b/history.tex
@@ -3,6 +3,10 @@ This document supersedes P0876R22.
 
 \uabschnitt{Changes since P0876R22}
 
+\begin{itemize}
+    \item Update recent WG21 history.
+\end{itemize}
+
 \uabschnitt{Changes since P0876R21}
 
 \begin{itemize}

--- a/references.tex
+++ b/references.tex
@@ -141,6 +141,10 @@
         \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p0876r21.pdf}
         {P0876R21: fibers without scheduler}
 
+    \bibitem{P0876R22}
+        \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p0876r22.pdf}
+        {P0876R22: fibers without scheduler}
+
     \bibitem{P1677R2}
         \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1677r2.pdf}
         {P1677R2: Cancellation is serendipitous-success}

--- a/rev
+++ b/rev
@@ -52,6 +52,28 @@ echo "Updating $oldrev -> $newrev"
 echo "$oldrev URL: $oldurl"
 echo "Previous to $oldrev was $prevrev"
 
+# To upload the newest rev as (e.g.) P0876R23.pdf rather than P0876.pdf, we
+# usually keep a hard link with the Rxx suffix to the plain generated
+# P0876.pdf. Interestingly, the texi2pdf command run by pdfy leaves the hard
+# link intact. (If that were not the case, we'd use a symlink instead, and
+# change this test accordingly.) Since at this point we think we know both the
+# old hard link name and the new, if we're right, update the hard link.
+basepdf="P${PNUM}.pdf"
+if [[ "$oldrev.pdf" -ef "$basepdf" ]]
+then
+    # $oldrev.pdf is a hard link to $basepdf, update it
+    mv -v "$oldrev.pdf" "$newrev.pdf"
+##elif [[ -L "$oldrev.pdf" && "$(readlink "$oldrev.pdf")" == "$basepdf" ]]
+##then
+##    (UNTESTED)
+##    # $oldrev.pdf is a symlink to $basepdf, update it
+##    mv -v "$oldrev.pdf" "newrev.pdf"
+else
+    # $oldrev.pdf doesn't exist, or is a file that isn't a link, or is a link
+    # to something else: just create $newrev.pdf
+    ln -v "$basepdf" "$newrev.pdf"
+fi
+
 ##git mv "$oldtex" "$newrev.tex"
 sed -i~ "s/$oldrev/$newrev/" "$oldtex"
 sed -i~ "s/$prevrev\\\\cite{$prevrev}/$oldrev\\\\cite{$oldrev}/" abstract.tex

--- a/wg21_process.tex
+++ b/wg21_process.tex
@@ -12,9 +12,11 @@ In January 2025, Andrzej Krzemieński
 posted \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3472r1.html}{P3472R1}
 requesting that change to \canresume. The authors accepted this as a friendly amendment, incorporating it
 into \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p0876r21.pdf}{P0876R21}.
-But this change necessitated another detour through LEWG to approve. As of the
-November 2025 meeting in Kona, LEWG declined to consider P0876R21 due to the
-large queue of NB comments.
+But this change necessitated another detour through LEWG to approve.
+
+In Croydon in March 2026,
+LEWG \href{https://github.com/cplusplus/papers/issues/2126}{approved P3472R1}
+and forwarded P0876R22 to LWG. LWG is now waiting on CWG before final LWG review.
 
 In Tokyo in March 2024, CWG finished initial P0876 Core wording review, with
 \href{https://wiki.edg.com/bin/view/Wg21tokyo2024/CoreWorkingGroup#D0876R16_fiber_context}{one requested change}:


### PR DESCRIPTION
The only substantive change from P0876R22 is to record LEWG approval from the Croydon meeting in March. But since I added "Recent WG21 History," I don't want it to get out of date.

Also I was able to remove LEWG from the target audience.

I have posted the resulting PDF to the paper system.

The largest change here is to the 'rev' bash script I use to perform the various housekeeping tasks associated with creating each new revision. Unless you use 'rev' yourself, you can safely ignore that.