### PR TITLE
Forbid longjmp across fibers; clarify nondeterminism of stack unwinding from uncaught exception.

### DIFF
--- a/P0876.tex
+++ b/P0876.tex
@@ -62,7 +62,7 @@
 \begin{document}
 \small
 \begin{tabbing}
-    Document number: \= P0876R23\\
+    Document number: \= D0876R24\\
     Date:            \> 2026-05-11\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat.cognitoy@gmail.com)\\

--- a/P0876.tex
+++ b/P0876.tex
@@ -63,7 +63,7 @@
 \small
 \begin{tabbing}
     Document number: \= D0876R24\\
-    Date:            \> 2026-05-11\\
+    Date:            \> 2026-06-05\\
     Author:          \> Oliver Kowalke (oliver.kowalke@gmail.com)\\
                      \> Nat Goodspeed (nat.cognitoy@gmail.com)\\
     Audience:        \> LWG, CWG\\

--- a/abstract.tex
+++ b/abstract.tex
@@ -8,7 +8,7 @@ constructs such as stackful coroutines as well as cooperative multitasking
 
 This revision addresses concerns, questions and suggestions from the past meetings.
 The proposed API supersedes the former proposals N3985\cite{N3985},
-P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3} and P0876R22\cite{P0876R22}.
+P0099R1\cite{P0099R1}, P0534R3\cite{P0534R3} and P0876R23\cite{P0876R23}.
 
 Because of name clashes with \emph{coroutine} from C++20,
 \emph{execution context} from executor proposals and \emph{continuation} used

--- a/api.tex
+++ b/api.tex
@@ -109,6 +109,18 @@ returns the number of uncaught exceptions in the
 1 \emph{Returns:} The number of uncaught exceptions \xref{except.throw} in the
 \replace{current thread}{running fiber ([intro.fibers])}.
 
+\zs{Modify \stdsection{17.14.3}{csetjmp.syn} paragraph 2 as indicated:}
+
+The function signature \cpp{longjmp(jmp\_buf jbuf, int val)} has more
+restricted behavior in this document. A \cpp{setjmp/longjmp} call pair has
+undefined behavior if replacing the \cpp{setjmp} and \cpp{longjmp}
+by \cpp{catch} and \cpp{throw} would invoke any non-trivial destructors for
+any objects with automatic storage duration.
+\add{A call to \cpp{longjmp} specifying a \cpp{jmp\_buf}}
+\add{initialized by a \cpp{setjmp} call executed on a different fiber has undefined behavior.}
+A call to \cpp{setjmp} or \cpp{longjmp} has undefined behavior if invoked in a
+suspension context of a coroutine \xref{expr.await}.
+
 \zs{Insert new final subclause in clause 32 \stdclause{thread} as indicated:}
 
 \setcounter{section}{32}

--- a/exceptions.tex
+++ b/exceptions.tex
@@ -3,6 +3,8 @@
 %% In general,
 If an uncaught exception escapes from a fiber's \entryfn,
 \cpp{std::terminate} is called.
+Whether the stack is unwound before \cpp{std::terminate} is
+implementation-defined \xref{except.handle\#8}.
 %% There is one exception: the \foreignex used to
 %% unwind fiber stacks. The \fiber facility internally uses this \foreignex to
 %% clean up the stack of a suspended fiber being destroyed. Because this

--- a/history.tex
+++ b/history.tex
@@ -5,6 +5,8 @@ This document supersedes P0876R23.
 
 \begin{itemize}
     \item Modify \stdclause{csetjmp.syn} to forbid \cpp{longjmp} across fibers.
+    \item Clarify that, in addition to calling \cpp{std::terminate}, an
+          uncaught exception from a fiber may or may not unwind the stack.
 \end{itemize}
 
 \uabschnitt{Changes since P0876R22}

--- a/history.tex
+++ b/history.tex
@@ -1,5 +1,7 @@
 \abschnitt{Revision History}\label{history}
-This document supersedes P0876R22.
+This document supersedes P0876R23.
+
+\uabschnitt{Changes since P0876R23}
 
 \uabschnitt{Changes since P0876R22}
 

--- a/history.tex
+++ b/history.tex
@@ -3,6 +3,10 @@ This document supersedes P0876R23.
 
 \uabschnitt{Changes since P0876R23}
 
+\begin{itemize}
+    \item Modify \stdclause{csetjmp.syn} to forbid \cpp{longjmp} across fibers.
+\end{itemize}
+
 \uabschnitt{Changes since P0876R22}
 
 \begin{itemize}

--- a/references.tex
+++ b/references.tex
@@ -145,6 +145,10 @@
         \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p0876r22.pdf}
         {P0876R22: fibers without scheduler}
 
+    \bibitem{P0876R23}
+        \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p0876r23.pdf}
+        {P0876R23: fibers without scheduler}
+
     \bibitem{P1677R2}
         \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1677r2.pdf}
         {P1677R2: Cancellation is serendipitous-success}

--- a/rev
+++ b/rev
@@ -67,7 +67,7 @@ then
 ##then
 ##    (UNTESTED)
 ##    # $oldrev.pdf is a symlink to $basepdf, update it
-##    mv -v "$oldrev.pdf" "newrev.pdf"
+##    mv -v "$oldrev.pdf" "$newrev.pdf"
 else
     # $oldrev.pdf doesn't exist, or is a file that isn't a link, or is a link
     # to something else: just create $newrev.pdf


### PR DESCRIPTION
These changes were requested in two email threads on the CWG reflector, from 2026-06-03.